### PR TITLE
added examples structures

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,11 @@
+# examples
+
+This folder contains examples showing how version bundles look like. The
+[kubernetes-operator.json](kubernetes-operator.json) shows the version bundles
+returned by the kubernetes-operator. It defines which versions it provides in
+which combinations with respect to its expected dependencies. The
+[cloud-config-operator.json](cloud-config-operator.json) shows the same for
+another microservice called cloud-config-operator. The
+[aggregation.json](aggregation.json) shows how the version bundles of the two
+mentioned operators are aggregated to reflect the combined version bundles as
+they can be used together.

--- a/examples/aggregation.json
+++ b/examples/aggregation.json
@@ -27,7 +27,7 @@
           ],
           "dependencies": [],
           "deprecated": false,
-          "time": "2017 Aug 17, 21:03 UTC",
+          "time": "2017-08-17T21:03:00Z",
           "version": "2.0.0",
           "wip": false
         }
@@ -66,7 +66,7 @@
             }
           ],
           "deprecated": false,
-          "time": "2017 Aug 18, 11:57 UTC",
+          "time": "2017-08-18T11:57:00Z",
           "version": "1.0.0",
           "wip": false
         }
@@ -102,7 +102,7 @@
           ],
           "dependencies": [],
           "deprecated": false,
-          "time": "2017 Aug 24, 09:11 UTC",
+          "time": "2017-08-24T09:11:00Z",
           "version": "2.1.0",
           "wip": false
         }
@@ -141,7 +141,7 @@
             }
           ],
           "deprecated": false,
-          "time": "2017 Aug 25, 16:40 UTC",
+          "time": "2017-08-25T16:40:00Z",
           "version": "2.0.0",
           "wip": false
         }

--- a/examples/aggregation.json
+++ b/examples/aggregation.json
@@ -1,0 +1,152 @@
+[
+  [
+    {
+      "bundles": [
+        {
+          "changelog": [
+            {
+              "component": "etcd",
+              "description": "Etcd version updated.",
+              "kind": "changed"
+            },
+            {
+              "component": "kubernetes",
+              "description": "Kubernetes version updated.",
+              "kind": "changed"
+            }
+          ],
+          "components": [
+            {
+              "name": "etcd",
+              "version": "3.2.0"
+            },
+            {
+              "name": "kubernetes",
+              "version": "1.7.1"
+            }
+          ],
+          "dependencies": [],
+          "deprecated": false,
+          "time": "2017 Aug 17, 21:03 UTC",
+          "version": "2.0.0",
+          "wip": false
+        }
+      ],
+      "name": "cloud-config-operator"
+    },
+    {
+      "bundles": [
+        {
+          "changelog": [
+            {
+              "component": "calico",
+              "description": "Calico version updated.",
+              "kind": "changed"
+            },
+            {
+              "component": "kubernetes",
+              "description": "Kubernetes version requirements changed due to calico update.",
+              "kind": "changed"
+            }
+          ],
+          "components": [
+            {
+              "name": "calico",
+              "version": "1.0.0"
+            },
+            {
+              "name": "kube-dns",
+              "version": "1.0.0"
+            }
+          ],
+          "dependencies": [
+            {
+              "name": "kubernetes",
+              "version": "<= 1.7.x"
+            }
+          ],
+          "deprecated": false,
+          "time": "2017 Aug 18, 11:57 UTC",
+          "version": "1.0.0",
+          "wip": false
+        }
+      ],
+      "name": "kubernetes-operator"
+    }
+  ],
+  [
+    {
+      "bundles": [
+        {
+          "changelog": [
+            {
+              "component": "etcd",
+              "description": "Etcd version updated.",
+              "kind": "changed"
+            },
+            {
+              "component": "kubernetes",
+              "description": "Kubernetes version updated.",
+              "kind": "changed"
+            }
+          ],
+          "components": [
+            {
+              "name": "etcd",
+              "version": "3.2.4"
+            },
+            {
+              "name": "kubernetes",
+              "version": "1.8.2"
+            }
+          ],
+          "dependencies": [],
+          "deprecated": false,
+          "time": "2017 Aug 24, 09:11 UTC",
+          "version": "2.1.0",
+          "wip": false
+        }
+      ],
+      "name": "cloud-config-operator"
+    },
+    {
+      "bundles": [
+        {
+          "changelog": [
+            {
+              "component": "calico",
+              "description": "Calico version updated.",
+              "kind": "changed"
+            },
+            {
+              "component": "kubernetes",
+              "description": "Kubernetes version requirements changed due to calico update.",
+              "kind": "changed"
+            }
+          ],
+          "components": [
+            {
+              "name": "calico",
+              "version": "2.0.0"
+            },
+            {
+              "name": "kube-dns",
+              "version": "1.0.0"
+            }
+          ],
+          "dependencies": [
+            {
+              "name": "kubernetes",
+              "version": "<= 1.8.x"
+            }
+          ],
+          "deprecated": false,
+          "time": "2017 Aug 25, 16:40 UTC",
+          "version": "2.0.0",
+          "wip": false
+        }
+      ],
+      "name": "kubernetes-operator"
+    }
+  ]
+]

--- a/examples/cloud-config-operator.json
+++ b/examples/cloud-config-operator.json
@@ -1,0 +1,63 @@
+{
+  "bundles": [
+    {
+      "changelog": [
+        {
+          "component": "etcd",
+          "description": "Etcd version updated.",
+          "kind": "changed"
+        },
+        {
+          "component": "kubernetes",
+          "description": "Kubernetes version updated.",
+          "kind": "changed"
+        }
+      ],
+      "components": [
+        {
+          "name": "etcd",
+          "version": "3.2.0"
+        },
+        {
+          "name": "kubernetes",
+          "version": "1.7.1"
+        }
+      ],
+      "dependencies": [],
+      "deprecated": false,
+      "time": "2017 Aug 17, 21:03 UTC",
+      "version": "2.0.0",
+      "wip": false
+    },
+    {
+      "changelog": [
+        {
+          "component": "etcd",
+          "description": "Etcd version updated.",
+          "kind": "changed"
+        },
+        {
+          "component": "kubernetes",
+          "description": "Kubernetes version updated.",
+          "kind": "changed"
+        }
+      ],
+      "components": [
+        {
+          "name": "etcd",
+          "version": "3.2.4"
+        },
+        {
+          "name": "kubernetes",
+          "version": "1.8.2"
+        }
+      ],
+      "dependencies": [],
+      "deprecated": false,
+      "time": "2017 Aug 24, 09:11 UTC",
+      "version": "2.1.0",
+      "wip": false
+    }
+  ],
+  "name": "cloud-config-operator"
+}

--- a/examples/cloud-config-operator.json
+++ b/examples/cloud-config-operator.json
@@ -25,7 +25,7 @@
       ],
       "dependencies": [],
       "deprecated": false,
-      "time": "2017 Aug 17, 21:03 UTC",
+      "time": "2017-08-17T21:03:00Z",
       "version": "2.0.0",
       "wip": false
     },
@@ -54,7 +54,7 @@
       ],
       "dependencies": [],
       "deprecated": false,
-      "time": "2017 Aug 24, 09:11 UTC",
+      "time": "2017-08-24T09:11:00Z",
       "version": "2.1.0",
       "wip": false
     }

--- a/examples/kubernetes-operator.json
+++ b/examples/kubernetes-operator.json
@@ -1,0 +1,73 @@
+{
+  "bundles": [
+    {
+      "changelog": [
+        {
+          "component": "calico",
+          "description": "Calico version updated.",
+          "kind": "changed"
+        },
+        {
+          "component": "kubernetes",
+          "description": "Kubernetes version requirements changed due to calico update.",
+          "kind": "changed"
+        }
+      ],
+      "components": [
+        {
+          "name": "calico",
+          "version": "1.0.0"
+        },
+        {
+          "name": "kube-dns",
+          "version": "1.0.0"
+        }
+      ],
+      "dependencies": [
+        {
+          "name": "kubernetes",
+          "version": "<= 1.7.x"
+        }
+      ],
+      "deprecated": false,
+      "time": "2017 Aug 18, 11:57 UTC",
+      "version": "1.0.0",
+      "wip": false
+    },
+    {
+      "changelog": [
+        {
+          "component": "calico",
+          "description": "Calico version updated.",
+          "kind": "changed"
+        },
+        {
+          "component": "kubernetes",
+          "description": "Kubernetes version requirements changed due to calico update.",
+          "kind": "changed"
+        }
+      ],
+      "components": [
+        {
+          "name": "calico",
+          "version": "2.0.0"
+        },
+        {
+          "name": "kube-dns",
+          "version": "1.0.0"
+        }
+      ],
+      "dependencies": [
+        {
+          "name": "kubernetes",
+          "version": "<= 1.8.x"
+        }
+      ],
+      "deprecated": false,
+      "time": "2017 Aug 25, 16:40 UTC",
+      "version": "2.0.0",
+      "wip": false
+    }
+  ],
+  "name": "kubernetes-operator"
+}

--- a/examples/kubernetes-operator.json
+++ b/examples/kubernetes-operator.json
@@ -30,7 +30,7 @@
         }
       ],
       "deprecated": false,
-      "time": "2017 Aug 18, 11:57 UTC",
+      "time": "2017-08-18T11:57:00Z",
       "version": "1.0.0",
       "wip": false
     },
@@ -64,7 +64,7 @@
         }
       ],
       "deprecated": false,
-      "time": "2017 Aug 25, 16:40 UTC",
+      "time": "2017-08-25T16:40:00Z",
       "version": "2.0.0",
       "wip": false
     }


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/1918. 

This PR introduces a new library which we want to use internally to represent version bundles. The format shown here is probably not final and can change over time. I would like to prevent trying to make this perfect now and just move on since I think the suggestion is open enough to not block us in the future. Note that there is another PR which implements the suggested scheme already. See https://github.com/giantswarm/versionbundle/pull/1. There are structures and tests for the scheme itself and its aggregation. I had to did this work to validate the idea of the scheme because I had to find out if the aggregation/merge can be done as I had in mind. More explanations towards the structures and their properties will be added in the next steps in the other PR. Also note that the representation to users (e.g. via our API) is still TBD and might differ (internal vs external) fro this structure. 