### PR TITLE
Add active to release

### DIFF
--- a/release.go
+++ b/release.go
@@ -27,6 +27,7 @@ type Release struct {
 	timestamp  string
 	version    string
 	wip        bool
+	active     bool
 }
 
 func NewRelease(config ReleaseConfig) (Release, error) {
@@ -95,6 +96,10 @@ func NewRelease(config ReleaseConfig) (Release, error) {
 	}
 
 	return r, nil
+}
+
+func (r Release) Active() bool {
+	return !(r.Deprecated() || r.WIP())
 }
 
 func (r Release) Bundles() []Bundle {

--- a/release_test.go
+++ b/release_test.go
@@ -6,6 +6,52 @@ import (
 	"time"
 )
 
+func Test_Release_Active(t *testing.T) {
+	testCases := []struct {
+		Release        Release
+		ExpectedActive bool
+	}{
+		// Test 0: A release that is not WIP and not Deprecated should be considered Active
+		{
+			Release: Release{
+				wip:        false,
+				deprecated: false,
+			},
+			ExpectedActive: true,
+		},
+		// Test 1: A release that is WIP but not Deprecated should not be considered Active
+		{
+			Release: Release{
+				wip:        true,
+				deprecated: false,
+			},
+			ExpectedActive: false,
+		},
+		// Test 2: A release that is not WIP but is Deprecated should not be considered Active
+		{
+			Release: Release{
+				wip:        false,
+				deprecated: true,
+			},
+			ExpectedActive: false,
+		},
+		// Test 3: A release that is WIP and Deprecated should not be considered Active
+		{
+			Release: Release{
+				wip:        true,
+				deprecated: true,
+			},
+			ExpectedActive: false,
+		},
+	}
+
+	for i, tc := range testCases {
+		if tc.Release.Active() != tc.ExpectedActive {
+			t.Fatalf("test %d: We expected a release to be 'active: %v' but got 'active: %v'", i, tc.ExpectedActive, tc.Release.Active())
+		}
+	}
+}
+
 func Test_Release_Changelogs(t *testing.T) {
 	testCases := []struct {
 		Bundles            []Bundle


### PR DESCRIPTION
Soon I'll want to check wether or not a release is active in one more place in `cluster-service`.

Instead of duplicating that logic there, I decided to bestow the knowledge of whether or not a release is active to the release itself.