### PR TITLE
Add Provider field to Bundle

### DIFF
--- a/bundle.go
+++ b/bundle.go
@@ -37,6 +37,9 @@ type Bundle struct {
 	//
 	// NOTE that once this property is set it must never change again.
 	Name string `json:"name" yaml:"name"`
+	// Provider describes infrastructure provider that is specific for this
+	// Bundle.
+	Provider string `json:"provider,omitempty" yaml:"provider,omitempty"`
 	// Time describes the time this version bundle got introduced.
 	//
 	// NOTE that once this property is set it must never change again.

--- a/bundles.go
+++ b/bundles.go
@@ -68,7 +68,7 @@ func (b Bundles) hasDuplicatedVersions() bool {
 		var seen int
 
 		for _, b2 := range b {
-			if b1.Version == b2.Version {
+			if b1.Version == b2.Version && b1.Provider == b2.Provider {
 				seen++
 
 				if seen >= 2 {
@@ -113,9 +113,47 @@ func GetBundleByName(bundles []Bundle, name string) (Bundle, error) {
 	return Bundle{}, microerror.Maskf(bundleNotFoundError, name)
 }
 
-func GetNewestBundle(bundles []Bundle) (Bundle, error) {
+func GetBundleByNameForProvider(bundles []Bundle, name, provider string) (Bundle, error) {
 	if len(bundles) == 0 {
 		return Bundle{}, microerror.Maskf(executionFailedError, "bundles must not be empty")
+	}
+	if name == "" {
+		return Bundle{}, microerror.Maskf(executionFailedError, "name must not be empty")
+	}
+	if provider == "" {
+		return Bundle{}, microerror.Maskf(executionFailedError, "provider must not be empty")
+	}
+
+	for _, b := range bundles {
+		if b.Name == name && b.Provider == provider {
+			return b, nil
+		}
+	}
+
+	return Bundle{}, microerror.Maskf(bundleNotFoundError, name)
+}
+
+func GetNewestBundle(bundles []Bundle) (Bundle, error) {
+	return GetNewestBundleForProvider(bundles, "")
+}
+
+func GetNewestBundleForProvider(bundles []Bundle, provider string) (Bundle, error) {
+	if len(bundles) == 0 {
+		return Bundle{}, microerror.Maskf(executionFailedError, "bundles must not be empty")
+	}
+
+	// filter bundles by provider if provider is specificed
+	if provider != "" {
+		for i := 0; i < len(bundles); i++ {
+			if bundles[i].Provider != provider {
+				bundles = append(bundles[:i], bundles[i+1:]...)
+				i--
+			}
+		}
+	}
+
+	if len(bundles) == 0 {
+		return Bundle{}, microerror.Maskf(bundleNotFoundError, "no bundle found for provider %s", provider)
 	}
 
 	s := SortBundlesByVersion(bundles)

--- a/bundles_test.go
+++ b/bundles_test.go
@@ -670,6 +670,398 @@ func Test_Bundles_GetBundleByName(t *testing.T) {
 	}
 }
 
+func Test_Bundles_GetBundleByNameForProvider(t *testing.T) {
+	testCases := []struct {
+		Bundles        []Bundle
+		Name           string
+		Provider       string
+		ExpectedBundle Bundle
+		ErrorMatcher   func(err error) bool
+	}{
+		// Test 0 ensures that a nil list and an empty name throws an execution
+		// failed error.
+		{
+			Bundles:        nil,
+			Name:           "",
+			Provider:       "aws",
+			ExpectedBundle: Bundle{},
+			ErrorMatcher:   IsExecutionFailed,
+		},
+
+		// Test 1 ensures that a nil list and a non-empty name throws an execution
+		// failed error.
+		{
+			Bundles:        nil,
+			Name:           "kubernetes-operator",
+			Provider:       "aws",
+			ExpectedBundle: Bundle{},
+			ErrorMatcher:   IsExecutionFailed,
+		},
+
+		// Test 2 ensures that a non-empty list and an empty name throws an execution
+		// failed error.
+		{
+			Bundles: []Bundle{
+				{
+					Changelogs: []Changelog{},
+					Components: []Component{
+						{
+							Name:    "calico",
+							Version: "1.1.0",
+						},
+						{
+							Name:    "kube-dns",
+							Version: "1.0.0",
+						},
+					},
+					Dependencies: []Dependency{
+						{
+							Name:    "kubernetes",
+							Version: "<= 1.7.x",
+						},
+					},
+					Deprecated: false,
+					Name:       "kubernetes-operator",
+					Time:       time.Unix(10, 5),
+					Version:    "0.1.0",
+					WIP:        false,
+				},
+			},
+			Name:           "",
+			Provider:       "",
+			ExpectedBundle: Bundle{},
+			ErrorMatcher:   IsExecutionFailed,
+		},
+
+		// Test 3 ensures that a non-empty list and an non-empty name throws a
+		// not found errorn case the given name does not exist in the given list.
+		{
+			Bundles: []Bundle{
+				{
+					Changelogs: []Changelog{},
+					Components: []Component{
+						{
+							Name:    "calico",
+							Version: "1.1.0",
+						},
+						{
+							Name:    "kube-dns",
+							Version: "1.0.0",
+						},
+					},
+					Dependencies: []Dependency{
+						{
+							Name:    "kubernetes",
+							Version: "<= 1.7.x",
+						},
+					},
+					Deprecated: false,
+					Name:       "kubernetes-operator",
+					Provider:   "aws",
+					Time:       time.Unix(10, 5),
+					Version:    "0.1.0",
+					WIP:        false,
+				},
+			},
+			Name:           "cert-operator",
+			Provider:       "aws",
+			ExpectedBundle: Bundle{},
+			ErrorMatcher:   IsBundleNotFound,
+		},
+
+		// Test 4 is the same as 3 but with different version bundles.
+		{
+			Bundles: []Bundle{
+				{
+					Changelogs: []Changelog{},
+					Components: []Component{
+						{
+							Name:    "calico",
+							Version: "1.1.0",
+						},
+						{
+							Name:    "kube-dns",
+							Version: "1.0.0",
+						},
+					},
+					Dependencies: []Dependency{
+						{
+							Name:    "kubernetes",
+							Version: "<= 1.7.x",
+						},
+					},
+					Deprecated: false,
+					Name:       "kubernetes-operator",
+					Provider:   "aws",
+					Time:       time.Unix(10, 5),
+					Version:    "0.1.0",
+					WIP:        false,
+				},
+				{
+					Changelogs: []Changelog{},
+					Components: []Component{
+						{
+							Name:    "calico",
+							Version: "1.1.0",
+						},
+						{
+							Name:    "kubernetes",
+							Version: "1.7.5",
+						},
+					},
+					Dependencies: []Dependency{},
+					Deprecated:   false,
+					Name:         "cloud-config-operator",
+					Provider:     "aws",
+					Time:         time.Unix(10, 5),
+					Version:      "0.1.0",
+					WIP:          false,
+				},
+			},
+			Name:           "cert-operator",
+			Provider:       "aws",
+			ExpectedBundle: Bundle{},
+			ErrorMatcher:   IsBundleNotFound,
+		},
+
+		// Test 5 ensures that a bundle can be found.
+		{
+			Bundles: []Bundle{
+				{
+					Changelogs: []Changelog{},
+					Components: []Component{
+						{
+							Name:    "calico",
+							Version: "1.1.0",
+						},
+						{
+							Name:    "kubernetes",
+							Version: "1.7.5",
+						},
+					},
+					Dependencies: []Dependency{},
+					Deprecated:   false,
+					Name:         "cloud-config-operator",
+					Provider:     "aws",
+					Time:         time.Unix(10, 5),
+					Version:      "0.1.0",
+					WIP:          false,
+				},
+			},
+			Name:     "cloud-config-operator",
+			Provider: "aws",
+			ExpectedBundle: Bundle{
+				Changelogs: []Changelog{},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kubernetes",
+						Version: "1.7.5",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "cloud-config-operator",
+				Provider:     "aws",
+				Time:         time.Unix(10, 5),
+				Version:      "0.1.0",
+				WIP:          false,
+			},
+			ErrorMatcher: nil,
+		},
+
+		// Test 6 is the same as 5 but with different bundles.
+		{
+			Bundles: []Bundle{
+				{
+					Changelogs: []Changelog{},
+					Components: []Component{
+						{
+							Name:    "calico",
+							Version: "1.1.0",
+						},
+						{
+							Name:    "kube-dns",
+							Version: "1.0.0",
+						},
+					},
+					Dependencies: []Dependency{
+						{
+							Name:    "kubernetes",
+							Version: "<= 1.7.x",
+						},
+					},
+					Deprecated: false,
+					Name:       "kubernetes-operator",
+					Provider:   "azure",
+					Time:       time.Unix(10, 5),
+					Version:    "0.1.0",
+					WIP:        false,
+				},
+				{
+					Changelogs: []Changelog{},
+					Components: []Component{
+						{
+							Name:    "calico",
+							Version: "1.1.0",
+						},
+						{
+							Name:    "kubernetes",
+							Version: "1.7.5",
+						},
+					},
+					Dependencies: []Dependency{},
+					Deprecated:   false,
+					Name:         "cloud-config-operator",
+					Provider:     "azure",
+					Time:         time.Unix(10, 5),
+					Version:      "0.1.0",
+					WIP:          false,
+				},
+			},
+			Name:     "cloud-config-operator",
+			Provider: "azure",
+			ExpectedBundle: Bundle{
+				Changelogs: []Changelog{},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kubernetes",
+						Version: "1.7.5",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "cloud-config-operator",
+				Provider:     "azure",
+				Time:         time.Unix(10, 5),
+				Version:      "0.1.0",
+				WIP:          false,
+			},
+			ErrorMatcher: nil,
+		},
+
+		// Test 7 is the same as 5 but with different bundles.
+		{
+			Bundles: []Bundle{
+				{
+					Changelogs: []Changelog{},
+					Components: []Component{
+						{
+							Name:    "calico",
+							Version: "1.1.0",
+						},
+						{
+							Name:    "kube-dns",
+							Version: "1.0.0",
+						},
+					},
+					Dependencies: []Dependency{
+						{
+							Name:    "kubernetes",
+							Version: "<= 1.7.x",
+						},
+					},
+					Deprecated: false,
+					Name:       "kubernetes-operator",
+					Provider:   "azure",
+					Time:       time.Unix(10, 5),
+					Version:    "0.1.0",
+					WIP:        false,
+				},
+				{
+					Changelogs: []Changelog{},
+					Components: []Component{
+						{
+							Name:    "calico",
+							Version: "1.1.0",
+						},
+						{
+							Name:    "kubernetes",
+							Version: "1.7.5",
+						},
+					},
+					Dependencies: []Dependency{},
+					Deprecated:   false,
+					Name:         "cloud-config-operator",
+					Provider:     "azure",
+					Time:         time.Unix(10, 5),
+					Version:      "0.1.0",
+					WIP:          false,
+				},
+				{
+					Changelogs:   []Changelog{},
+					Components:   []Component{},
+					Dependencies: []Dependency{},
+					Deprecated:   false,
+					Provider:     "aws",
+					Name:         "cluster-operator",
+					Time:         time.Unix(20, 15),
+					Version:      "0.1.0",
+					WIP:          false,
+				},
+				{
+					Changelogs:   []Changelog{},
+					Components:   []Component{},
+					Dependencies: []Dependency{},
+					Deprecated:   false,
+					Provider:     "azure",
+					Name:         "cluster-operator",
+					Time:         time.Unix(40, 35),
+					Version:      "0.1.0",
+					WIP:          false,
+				},
+				{
+					Changelogs:   []Changelog{},
+					Components:   []Component{},
+					Dependencies: []Dependency{},
+					Deprecated:   false,
+					Provider:     "kvm",
+					Name:         "cluster-operator",
+					Time:         time.Unix(10, 5),
+					Version:      "0.1.0",
+					WIP:          false,
+				},
+			},
+			Name:     "cluster-operator",
+			Provider: "azure",
+			ExpectedBundle: Bundle{
+				Changelogs:   []Changelog{},
+				Components:   []Component{},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Provider:     "azure",
+				Name:         "cluster-operator",
+				Time:         time.Unix(40, 35),
+				Version:      "0.1.0",
+				WIP:          false,
+			},
+			ErrorMatcher: nil,
+		},
+	}
+
+	for i, tc := range testCases {
+		result, err := GetBundleByNameForProvider(tc.Bundles, tc.Name, tc.Provider)
+		if tc.ErrorMatcher != nil {
+			if !tc.ErrorMatcher(err) {
+				t.Fatalf("test %d expected %#v got %#v", i, true, false)
+			}
+		} else if err != nil {
+			t.Fatalf("test %d expected %#v got %#v", i, nil, err)
+		} else {
+			if !reflect.DeepEqual(result, tc.ExpectedBundle) {
+				t.Fatalf("test %d expected %#v got %#v", i, tc.ExpectedBundle, result)
+			}
+		}
+	}
+}
+
 func Test_Bundles_GetNewestBundle(t *testing.T) {
 	testCases := []struct {
 		Bundles        []Bundle
@@ -1025,6 +1417,158 @@ func Test_Bundles_GetNewestBundle(t *testing.T) {
 
 	for i, tc := range testCases {
 		result, err := GetNewestBundle(tc.Bundles)
+		if tc.ErrorMatcher != nil {
+			if !tc.ErrorMatcher(err) {
+				t.Fatalf("test %d expected %#v got %#v", i, true, false)
+			}
+		} else if err != nil {
+			t.Fatalf("test %d expected %#v got %#v", i, nil, err)
+		} else {
+			if !reflect.DeepEqual(result, tc.ExpectedBundle) {
+				t.Fatalf("test %d expected %#v got %#v", i, tc.ExpectedBundle, result)
+			}
+		}
+	}
+}
+
+func Test_Bundles_GetNewestBundleForProvider(t *testing.T) {
+	testCases := []struct {
+		Bundles        []Bundle
+		Provider       string
+		ExpectedBundle Bundle
+		ErrorMatcher   func(err error) bool
+	}{
+		// Test 0 verifies that newest bundle can be found for provider.
+		{
+			Bundles: []Bundle{
+				{
+					Changelogs:   []Changelog{},
+					Components:   []Component{},
+					Dependencies: []Dependency{},
+					Deprecated:   false,
+					Provider:     "aws",
+					Name:         "cluster-operator",
+					Time:         time.Unix(20, 15),
+					Version:      "0.1.0",
+					WIP:          false,
+				},
+				{
+					Changelogs:   []Changelog{},
+					Components:   []Component{},
+					Dependencies: []Dependency{},
+					Deprecated:   false,
+					Provider:     "azure",
+					Name:         "cluster-operator",
+					Time:         time.Unix(40, 35),
+					Version:      "0.1.0",
+					WIP:          false,
+				},
+				{
+					Changelogs:   []Changelog{},
+					Components:   []Component{},
+					Dependencies: []Dependency{},
+					Deprecated:   false,
+					Provider:     "kvm",
+					Name:         "cluster-operator",
+					Time:         time.Unix(10, 5),
+					Version:      "0.1.0",
+					WIP:          false,
+				},
+				{
+					Changelogs:   []Changelog{},
+					Components:   []Component{},
+					Dependencies: []Dependency{},
+					Deprecated:   false,
+					Provider:     "aws",
+					Name:         "cluster-operator",
+					Time:         time.Unix(120, 15),
+					Version:      "0.2.0",
+					WIP:          false,
+				},
+				{
+					Changelogs:   []Changelog{},
+					Components:   []Component{},
+					Dependencies: []Dependency{},
+					Deprecated:   false,
+					Provider:     "azure",
+					Name:         "cluster-operator",
+					Time:         time.Unix(140, 35),
+					Version:      "0.4.0",
+					WIP:          false,
+				},
+				{
+					Changelogs:   []Changelog{},
+					Components:   []Component{},
+					Dependencies: []Dependency{},
+					Deprecated:   false,
+					Provider:     "kvm",
+					Name:         "cluster-operator",
+					Time:         time.Unix(110, 5),
+					Version:      "0.3.0",
+					WIP:          false,
+				},
+			},
+			Provider: "kvm",
+			ExpectedBundle: Bundle{
+				Changelogs:   []Changelog{},
+				Components:   []Component{},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Provider:     "kvm",
+				Name:         "cluster-operator",
+				Time:         time.Unix(110, 5),
+				Version:      "0.3.0",
+				WIP:          false,
+			},
+			ErrorMatcher: nil,
+		},
+
+		// Test 1 verifies that bundleNotFoundError is returned for missing
+		// provider.
+		{
+			Bundles: []Bundle{
+				{
+					Changelogs:   []Changelog{},
+					Components:   []Component{},
+					Dependencies: []Dependency{},
+					Deprecated:   false,
+					Provider:     "aws",
+					Name:         "cluster-operator",
+					Time:         time.Unix(20, 15),
+					Version:      "0.1.0",
+					WIP:          false,
+				},
+				{
+					Changelogs:   []Changelog{},
+					Components:   []Component{},
+					Dependencies: []Dependency{},
+					Deprecated:   false,
+					Provider:     "azure",
+					Name:         "cluster-operator",
+					Time:         time.Unix(40, 35),
+					Version:      "0.1.0",
+					WIP:          false,
+				},
+				{
+					Changelogs:   []Changelog{},
+					Components:   []Component{},
+					Dependencies: []Dependency{},
+					Deprecated:   false,
+					Provider:     "kvm",
+					Name:         "cluster-operator",
+					Time:         time.Unix(10, 5),
+					Version:      "0.1.0",
+					WIP:          false,
+				},
+			},
+			Provider:       "bluemix",
+			ExpectedBundle: Bundle{},
+			ErrorMatcher:   IsBundleNotFound,
+		},
+	}
+
+	for i, tc := range testCases {
+		result, err := GetNewestBundleForProvider(tc.Bundles, tc.Provider)
 		if tc.ErrorMatcher != nil {
 			if !tc.ErrorMatcher(err) {
 				t.Fatalf("test %d expected %#v got %#v", i, true, false)


### PR DESCRIPTION
Currently there are occasions where version bundle might differ
depending on provider. One example is cluster-operator that is running
three operatorkit frameworks on parallel. One for each provider. Each of
these frameworks provide separate set of version bundles, but they all
are named under cluster-operator. Therefore something is needed to
distinguish them from each other.

Adding Provider field to Bundle is a compromise between adding (too?)
flexible Labels map[string]string and having separate name for each
framework.

If it is later learned that this was a bad decision, this can be easily
removed or refactored to Labels.