### PR TITLE
Validate Bundles version increment per Provider

### DIFF
--- a/bundles.go
+++ b/bundles.go
@@ -32,12 +32,19 @@ func (b Bundles) Validate() error {
 		return microerror.Maskf(invalidBundlesError, "version bundle versions must be unique")
 	}
 
-	b1 := CopyBundles(b)
-	b2 := CopyBundles(b)
-	sort.Sort(SortBundlesByTime(b1))
-	sort.Sort(SortBundlesByVersion(b2))
-	if !reflect.DeepEqual(b1, b2) {
-		return microerror.Maskf(invalidBundlesError, "version bundle versions must always increment")
+	perProviderVersions := make(map[string][]Bundle, 0)
+	for _, v := range b {
+		perProviderVersions[v.Provider] = append(perProviderVersions[v.Provider], v)
+	}
+
+	for _, v := range perProviderVersions {
+		b1 := CopyBundles(v)
+		b2 := CopyBundles(v)
+		sort.Sort(SortBundlesByTime(b1))
+		sort.Sort(SortBundlesByVersion(b2))
+		if !reflect.DeepEqual(b1, b2) {
+			return microerror.Maskf(invalidBundlesError, "version bundle versions must always increment")
+		}
 	}
 
 	for _, bundle := range b {

--- a/bundles_test.go
+++ b/bundles_test.go
@@ -2227,7 +2227,7 @@ func Test_Bundles_Validate(t *testing.T) {
 			ErrorMatcher: IsInvalidBundlesError,
 		},
 
-		// Test 14 verifies that version increment is validated per provider
+		// Test 14 verifies that version increment is validated per provider.
 		{
 			Bundles: []Bundle{
 				{
@@ -2300,7 +2300,9 @@ func Test_Bundles_Validate(t *testing.T) {
 			ErrorMatcher: nil,
 		},
 
-		// Test 15 like test 14 but verifies invalidBundlesError
+		// Test 15 like test 14 but verifies invalidBundlesError when there are
+		// two Bundles for AWS provider and second of those has newer timestamp
+		// and lower version number.
 		{
 			Bundles: []Bundle{
 				{

--- a/bundles_test.go
+++ b/bundles_test.go
@@ -2226,6 +2226,174 @@ func Test_Bundles_Validate(t *testing.T) {
 			},
 			ErrorMatcher: IsInvalidBundlesError,
 		},
+
+		// Test 14 verifies that version increment is validated per provider
+		{
+			Bundles: []Bundle{
+				{
+					Changelogs: []Changelog{
+						{
+							Component:   "Cluster Operator",
+							Description: "Initial version for AWS.",
+							Kind:        "added",
+						},
+					},
+					Components: []Component{
+						{
+							Name:    "aws-operator",
+							Version: "1.0.0",
+						},
+					},
+					Dependencies: []Dependency{},
+					Deprecated:   false,
+					Provider:     "aws",
+					Name:         "cluster-operator",
+					Time:         time.Unix(20, 15),
+					Version:      "0.1.0",
+					WIP:          false,
+				},
+				{
+					Changelogs: []Changelog{
+						{
+							Component:   "Cluster Operator",
+							Description: "Initial version for Azure.",
+							Kind:        "added",
+						},
+					},
+					Components: []Component{
+						{
+							Name:    "azure-operator",
+							Version: "1.0.0",
+						},
+					},
+					Dependencies: []Dependency{},
+					Deprecated:   false,
+					Provider:     "azure",
+					Name:         "cluster-operator",
+					Time:         time.Unix(40, 35),
+					Version:      "0.1.0",
+					WIP:          false,
+				},
+				{
+					Changelogs: []Changelog{
+						{
+							Component:   "Cluster Operator",
+							Description: "Initial version for KVM.",
+							Kind:        "added",
+						},
+					},
+					Components: []Component{
+						{
+							Name:    "kvm-operator",
+							Version: "1.0.0",
+						},
+					},
+					Dependencies: []Dependency{},
+					Deprecated:   false,
+					Provider:     "kvm",
+					Name:         "cluster-operator",
+					Time:         time.Unix(10, 5),
+					Version:      "0.1.0",
+					WIP:          false,
+				},
+			},
+			ErrorMatcher: nil,
+		},
+
+		// Test 15 like test 14 but verifies invalidBundlesError
+		{
+			Bundles: []Bundle{
+				{
+					Changelogs: []Changelog{
+						{
+							Component:   "Cluster Operator",
+							Description: "Initial version for AWS.",
+							Kind:        "added",
+						},
+					},
+					Components: []Component{
+						{
+							Name:    "aws-operator",
+							Version: "1.0.0",
+						},
+					},
+					Dependencies: []Dependency{},
+					Deprecated:   false,
+					Provider:     "aws",
+					Name:         "cluster-operator",
+					Time:         time.Unix(20, 15),
+					Version:      "1.0.0",
+					WIP:          false,
+				},
+				{
+					Changelogs: []Changelog{
+						{
+							Component:   "Cluster Operator",
+							Description: "Updated version for AWS.",
+							Kind:        "updated",
+						},
+					},
+					Components: []Component{
+						{
+							Name:    "aws-operator",
+							Version: "1.0.0",
+						},
+					},
+					Dependencies: []Dependency{},
+					Deprecated:   false,
+					Provider:     "aws",
+					Name:         "cluster-operator",
+					Time:         time.Unix(30, 15),
+					Version:      "0.1.0",
+					WIP:          false,
+				},
+				{
+					Changelogs: []Changelog{
+						{
+							Component:   "Cluster Operator",
+							Description: "Initial version for Azure.",
+							Kind:        "added",
+						},
+					},
+					Components: []Component{
+						{
+							Name:    "azure-operator",
+							Version: "1.0.0",
+						},
+					},
+					Dependencies: []Dependency{},
+					Deprecated:   false,
+					Provider:     "azure",
+					Name:         "cluster-operator",
+					Time:         time.Unix(40, 35),
+					Version:      "0.1.0",
+					WIP:          false,
+				},
+				{
+					Changelogs: []Changelog{
+						{
+							Component:   "Cluster Operator",
+							Description: "Initial version for KVM.",
+							Kind:        "added",
+						},
+					},
+					Components: []Component{
+						{
+							Name:    "kvm-operator",
+							Version: "1.0.0",
+						},
+					},
+					Dependencies: []Dependency{},
+					Deprecated:   false,
+					Provider:     "kvm",
+					Name:         "cluster-operator",
+					Time:         time.Unix(10, 5),
+					Version:      "0.1.0",
+					WIP:          false,
+				},
+			},
+			ErrorMatcher: IsInvalidBundlesError,
+		},
 	}
 
 	for i, tc := range testCases {


### PR DESCRIPTION
Overlooked this when added Provider field to Bundle. Found out when
taking this into use in cluster-operator.

Version increment must be validated per Provider. Version bundles for
diffrent providers live their own life but especially in the beginning
there are equal versions with slightly different timestamps.