### PR TITLE
Don't require non-empty component list for version bundle

### DIFF
--- a/bundle.go
+++ b/bundle.go
@@ -171,9 +171,6 @@ func (b Bundle) Validate() error {
 		}
 	}
 
-	if len(b.Components) == 0 {
-		return microerror.Maskf(invalidBundleError, "components must not be empty")
-	}
 	for _, c := range b.Components {
 		err := c.Validate()
 		if err != nil {

--- a/bundle_test.go
+++ b/bundle_test.go
@@ -1975,7 +1975,8 @@ func Test_Bundle_Validate(t *testing.T) {
 			ErrorMatcher: IsInvalidBundleError,
 		},
 
-		// Test 3 ensures a version bundle without components throws an error.
+		// Test 3 ensures a version bundle without components does not throw an
+		// error.
 		{
 			Bundle: Bundle{
 				Changelogs: []Changelog{
@@ -2003,7 +2004,7 @@ func Test_Bundle_Validate(t *testing.T) {
 				Version:    "0.1.0",
 				WIP:        false,
 			},
-			ErrorMatcher: IsInvalidBundleError,
+			ErrorMatcher: nil,
 		},
 
 		// Test 4 ensures a version bundle without dependencies does not throw an

--- a/bundles_test.go
+++ b/bundles_test.go
@@ -1698,8 +1698,8 @@ func Test_Bundles_Validate(t *testing.T) {
 			ErrorMatcher: IsInvalidBundlesError,
 		},
 
-		// Test 4 ensures validation of a list of version bundles where any version
-		// bundle has no components throws an error.
+		// Test 4 ensures validation of a list of version bundles where a
+		// version bundle has no components does not throw an error.
 		{
 			Bundles: []Bundle{
 				{
@@ -1729,7 +1729,7 @@ func Test_Bundles_Validate(t *testing.T) {
 					WIP:        false,
 				},
 			},
-			ErrorMatcher: IsInvalidBundlesError,
+			ErrorMatcher: nil,
 		},
 
 		// Test 5 is the same as 4 but with multiple version bundles.
@@ -1797,7 +1797,7 @@ func Test_Bundles_Validate(t *testing.T) {
 					WIP:        false,
 				},
 			},
-			ErrorMatcher: IsInvalidBundlesError,
+			ErrorMatcher: nil,
 		},
 
 		// Test 6 ensures validation of a list of version bundles where any version


### PR DESCRIPTION
There are situations where it's not useful to list any components for a
version bundle. Cluster-operator is one example here as theoretically
only reasonable component it could have is provider specific operator
such as aws-operator but it doesn't manage the version of it so listing
it in components would present misleading information in release bundle
component listing.