### PR TITLE
Allow bundles list to be empty for GetBundleByNameForProvider

### DIFF
--- a/bundles.go
+++ b/bundles.go
@@ -106,14 +106,14 @@ func GetBundleByName(bundles []Bundle, name string) (Bundle, error) {
 }
 
 func GetBundleByNameForProvider(bundles []Bundle, name, provider string) (Bundle, error) {
-	if len(bundles) == 0 {
-		return Bundle{}, microerror.Maskf(executionFailedError, "bundles must not be empty")
-	}
 	if name == "" {
 		return Bundle{}, microerror.Maskf(executionFailedError, "name must not be empty")
 	}
 	if provider == "" {
 		return Bundle{}, microerror.Maskf(executionFailedError, "provider must not be empty")
+	}
+	if len(bundles) == 0 {
+		return Bundle{}, microerror.Maskf(bundleNotFoundError, name)
 	}
 
 	for _, b := range bundles {

--- a/bundles_test.go
+++ b/bundles_test.go
@@ -695,7 +695,7 @@ func Test_Bundles_GetBundleByNameForProvider(t *testing.T) {
 			Name:           "kubernetes-operator",
 			Provider:       "aws",
 			ExpectedBundle: Bundle{},
-			ErrorMatcher:   IsExecutionFailed,
+			ErrorMatcher:   IsBundleNotFound,
 		},
 
 		// Test 2 ensures that a non-empty list and an empty name throws an execution


### PR DESCRIPTION
Returning bundleNotFoundError when searching bundle from empty list
makes sense and is more robust in case there are no version bundles.

This happened on one of the very old clusters that didn't have release
version at all.