### PR TITLE
Add release compilation from []IndexRelease & []Bundle

### DIFF
--- a/authority.go
+++ b/authority.go
@@ -2,6 +2,7 @@ package versionbundle
 
 import (
 	"net/url"
+	"strings"
 
 	"github.com/giantswarm/microerror"
 )
@@ -17,6 +18,13 @@ type Authority struct {
 // unmarshaling.
 type URL struct {
 	*url.URL
+}
+
+func (a Authority) BundleID() string {
+	n := strings.TrimSpace(a.Name)
+	p := strings.TrimSpace(a.Provider)
+	v := strings.TrimSpace(a.Version)
+	return n + ":" + p + ":" + v
 }
 
 func (u *URL) UnmarshalYAML(unmarshal func(interface{}) error) error {

--- a/bundle.go
+++ b/bundle.go
@@ -55,6 +55,13 @@ type Bundle struct {
 	WIP bool `json:"wip" yaml:"wip"`
 }
 
+func (b Bundle) ID() string {
+	n := strings.TrimSpace(b.Name)
+	p := strings.TrimSpace(b.Provider)
+	v := strings.TrimSpace(b.Version)
+	return n + ":" + p + ":" + v
+}
+
 func (b Bundle) IsMajorUpgrade(other Bundle) (bool, error) {
 	err := b.Validate()
 	if err != nil {

--- a/bundle_id_verification_test.go
+++ b/bundle_id_verification_test.go
@@ -1,0 +1,185 @@
+package versionbundle
+
+import "testing"
+
+func Test_VerifyBundleIDMatchAuthorityBundleID(t *testing.T) {
+	testCases := []struct {
+		name          string
+		bundle        Bundle
+		authority     Authority
+		expectedMatch bool
+	}{
+		{
+			name: "case 0: success with all fields set",
+			bundle: Bundle{
+				Name:     "foo-operator",
+				Provider: "hal9000",
+				Version:  "1.2.9",
+			},
+			authority: Authority{
+				Name:     "foo-operator",
+				Provider: "hal9000",
+				Version:  "1.2.9",
+			},
+			expectedMatch: true,
+		},
+		{
+			name: "case 1: success with Name and Version fields set",
+			bundle: Bundle{
+				Name:    "foo-operator",
+				Version: "1.2.9",
+			},
+			authority: Authority{
+				Name:    "foo-operator",
+				Version: "1.2.9",
+			},
+			expectedMatch: true,
+		},
+		{
+			name: "case 2: success with all fields set, space prefix in authority name",
+			bundle: Bundle{
+				Name:     "foo-operator",
+				Provider: "hal9000",
+				Version:  "1.2.9",
+			},
+			authority: Authority{
+				Name:     "  foo-operator",
+				Provider: "hal9000",
+				Version:  "1.2.9",
+			},
+			expectedMatch: true,
+		},
+		{
+			name: "case 3: success with all fields set, space prefix in bundle name",
+			bundle: Bundle{
+				Name:     "  foo-operator",
+				Provider: "hal9000",
+				Version:  "1.2.9",
+			},
+			authority: Authority{
+				Name:     "  foo-operator",
+				Provider: "hal9000",
+				Version:  "1.2.9",
+			},
+			expectedMatch: true,
+		},
+		{
+			name: "case 4: success with all fields set, space suffix in authority name",
+			bundle: Bundle{
+				Name:     "foo-operator",
+				Provider: "hal9000",
+				Version:  "1.2.9",
+			},
+			authority: Authority{
+				Name:     "foo-operator   ",
+				Provider: "hal9000",
+				Version:  "1.2.9",
+			},
+			expectedMatch: true,
+		},
+		{
+			name: "case 5: success with all fields set, space suffix in bundle name",
+			bundle: Bundle{
+				Name:     "foo-operator   ",
+				Provider: "hal9000",
+				Version:  "1.2.9",
+			},
+			authority: Authority{
+				Name:     "  foo-operator",
+				Provider: "hal9000",
+				Version:  "1.2.9",
+			},
+			expectedMatch: true,
+		},
+		{
+			name: "case 6: fail with different provider",
+			bundle: Bundle{
+				Name:     "foo-operator",
+				Provider: "hal9000",
+				Version:  "1.2.9",
+			},
+			authority: Authority{
+				Name:     "foo-operator",
+				Provider: "kvm",
+				Version:  "1.2.9",
+			},
+			expectedMatch: false,
+		},
+		{
+			name: "case 7: fail with different version",
+			bundle: Bundle{
+				Name:     "foo-operator",
+				Provider: "hal9000",
+				Version:  "1.2.9",
+			},
+			authority: Authority{
+				Name:     "foo-operator",
+				Provider: "hal9000",
+				Version:  "1.2.10",
+			},
+			expectedMatch: false,
+		},
+		{
+			name: "case 8: fail with different name",
+			bundle: Bundle{
+				Name:     "foo-operator",
+				Provider: "hal9000",
+				Version:  "1.2.9",
+			},
+			authority: Authority{
+				Name:     "bar-operator",
+				Provider: "hal9000",
+				Version:  "1.2.9",
+			},
+			expectedMatch: false,
+		},
+		{
+			name: "case 9: fail with other one missing provider",
+			bundle: Bundle{
+				Name:     "foo-operator",
+				Provider: "hal9000",
+				Version:  "1.2.9",
+			},
+			authority: Authority{
+				Name:    "foo-operator",
+				Version: "1.2.9",
+			},
+			expectedMatch: false,
+		},
+		{
+			name: "case 10: fail with other one missing version",
+			bundle: Bundle{
+				Name:     "foo-operator",
+				Provider: "hal9000",
+				Version:  "1.2.9",
+			},
+			authority: Authority{
+				Name:     "foo-operator",
+				Provider: "hal9000",
+			},
+			expectedMatch: false,
+		},
+		{
+			name: "case 11: fail with other one missing name",
+			bundle: Bundle{
+				Name:     "foo-operator",
+				Provider: "hal9000",
+				Version:  "1.2.9",
+			},
+			authority: Authority{
+				Provider: "hal9000",
+				Version:  "1.2.9",
+			},
+			expectedMatch: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			match := tc.bundle.ID() == tc.authority.BundleID()
+			if match != tc.expectedMatch {
+				t.Fatalf("expectedMatch: %v, got %v when bundle.ID() == %s and authority.BundleID() == %s", tc.expectedMatch, match, tc.bundle.ID(), tc.authority.BundleID())
+			}
+		})
+	}
+}

--- a/changelog.go
+++ b/changelog.go
@@ -57,6 +57,10 @@ type Changelog struct {
 	Kind kind `json:"kind" yaml:"kind"`
 }
 
+func (c Changelog) String() string {
+	return string(c.Kind) + ":" + c.Component + ":" + c.Description
+}
+
 func (c Changelog) Validate() error {
 	if c.Component == "" {
 		return microerror.Maskf(invalidChangelogError, "component must not be empty")

--- a/index_release.go
+++ b/index_release.go
@@ -3,6 +3,7 @@ package versionbundle
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 	"sort"
 	"strings"
 	"time"
@@ -23,14 +24,17 @@ type IndexRelease struct {
 // CompileReleases takes indexReleases and collected version bundles and
 // compiles canonicalized Releases from them.
 func CompileReleases(logger micrologger.Logger, indexReleases []IndexRelease, bundles []Bundle) ([]Release, error) {
-	releases := buildReleases(logger, indexReleases, bundles)
+	releases, err := buildReleases(logger, indexReleases, bundles)
+	if err != nil {
+		return nil, err
+	}
 
 	releases = deduplicateReleaseChangelog(releases)
 
 	return releases, nil
 }
 
-func buildReleases(logger micrologger.Logger, indexReleases []IndexRelease, bundles []Bundle) []Release {
+func buildReleases(logger micrologger.Logger, indexReleases []IndexRelease, bundles []Bundle) ([]Release, error) {
 	bundleCache := make(map[string]Bundle)
 
 	// Create cache of bundles for quick lookup
@@ -48,7 +52,7 @@ func buildReleases(logger micrologger.Logger, indexReleases []IndexRelease, bund
 		}
 
 		if err != nil {
-			panic(err)
+			return nil, err
 		}
 
 		rc := ReleaseConfig{
@@ -69,7 +73,7 @@ func buildReleases(logger micrologger.Logger, indexReleases []IndexRelease, bund
 		releases = append(releases, release)
 	}
 
-	return releases
+	return releases, nil
 }
 
 func groupBundlesForIndexRelease(ir IndexRelease, bundles map[string]Bundle) ([]Bundle, error) {

--- a/index_release.go
+++ b/index_release.go
@@ -51,12 +51,21 @@ func buildReleases(logger micrologger.Logger, indexReleases []IndexRelease, bund
 			panic(err)
 		}
 
-		release := Release{
-			active:    ir.Active,
-			bundles:   bundles,
-			timestamp: ir.Date.Format(indexReleaseTimestampFormat),
-			version:   ir.Version,
+		rc := ReleaseConfig{
+			Bundles: bundles,
 		}
+
+		release, err := NewRelease(rc)
+		if err != nil {
+			logger.Log("level", "warning", "message", err.Error())
+			continue
+		}
+
+		release.active = ir.Active
+		release.deprecated = false
+		release.timestamp = ir.Date.Format(indexReleaseTimestampFormat)
+		release.version = ir.Version
+
 		releases = append(releases, release)
 	}
 

--- a/index_release.go
+++ b/index_release.go
@@ -99,7 +99,7 @@ func deduplicateReleaseChangelog(releases []Release) []Release {
 	// First one is always there.
 	filteredReleases := append([]Release{}, releases[0])
 
-	for _, r := range releases {
+	for _, r := range releases[1:] {
 		curChangelogs := make(map[string]LogState)
 		for _, clog := range r.Changelogs() {
 			clogStr := clog.String()

--- a/index_release.go
+++ b/index_release.go
@@ -46,7 +46,7 @@ func buildReleases(indexReleases []IndexRelease, bundles []Bundle) ([]Release, e
 	for _, ir := range indexReleases {
 		release := Release{
 			active:    ir.Active,
-			timestamp: ir.Date.Format(releaseTimestampFormat),
+			timestamp: ir.Date.Format(indexReleaseTimestampFormat),
 			version:   ir.Version,
 		}
 

--- a/index_release.go
+++ b/index_release.go
@@ -25,7 +25,7 @@ type IndexRelease struct {
 func CompileReleases(logger micrologger.Logger, indexReleases []IndexRelease, bundles []Bundle) ([]Release, error) {
 	releases := buildReleases(logger, indexReleases, bundles)
 
-	deduplicateReleaseChangelog(releases)
+	releases = deduplicateReleaseChangelog(releases)
 
 	return releases, nil
 }

--- a/index_release.go
+++ b/index_release.go
@@ -90,7 +90,7 @@ func groupBundlesForIndexRelease(ir IndexRelease, bundles map[string]Bundle) ([]
 }
 
 // deduplicateReleaseChangelog removes duplicate changelog entries in
-// consequtive release entries. Core concept of algorithm here is to first sort
+// consecutive release entries. Core concept of algorithm here is to first sort
 // releases by their release version and then iterate them and compare current
 // release to previous one that fulfills following requirements: smaller
 // version number and earlier timestamp. Comparison of earlier timestamp is

--- a/index_release.go
+++ b/index_release.go
@@ -47,7 +47,7 @@ func buildReleases(logger micrologger.Logger, indexReleases []IndexRelease, bund
 	for _, ir := range indexReleases {
 		bundles, err := groupBundlesForIndexRelease(ir, bundleCache)
 		if IsBundleNotFound(err) {
-			logger.Log("level", "warning", "message", err.Error())
+			logger.Log("level", "warning", "message", fmt.Sprintf("failed grouping version bundles for release %s", ir.Version), "stack", fmt.Sprintf("%#v", err))
 			continue
 		}
 
@@ -61,7 +61,7 @@ func buildReleases(logger micrologger.Logger, indexReleases []IndexRelease, bund
 
 		release, err := NewRelease(rc)
 		if err != nil {
-			logger.Log("level", "warning", "message", err.Error())
+			logger.Log("level", "warning", "message", fmt.Sprintf("failed building new release from %s", ir.Version), "stack", fmt.Sprintf("%#v", err))
 			continue
 		}
 

--- a/index_release.go
+++ b/index_release.go
@@ -103,10 +103,12 @@ func deduplicateReleaseChangelog(releases []Release) []Release {
 		curChangelogs := make(map[string]LogState)
 		for _, clog := range r.Changelogs() {
 			clogStr := clog.String()
-			_, exists := prevChangelogs[clogStr]
+			state, exists := prevChangelogs[clogStr]
 			switch exists {
 			case true:
-				curChangelogs[clogStr] = Removed
+				if state == New {
+					curChangelogs[clogStr] = Removed
+				}
 				// r.Changelogs() returns a copy of changelogs so removal won't
 				// mess iteration in this case.
 				r.removeChangelogEntry(clog)

--- a/index_release_test.go
+++ b/index_release_test.go
@@ -36,7 +36,8 @@ func Test_deduplicateReleaseChangelog(t *testing.T) {
 							Kind:        KindAdded,
 						},
 					},
-					version: "1.0.0",
+					timestamp: "2018-05-02T12:00:00.000000Z",
+					version:   "1.0.0",
 				},
 				{
 					changelogs: []Changelog{
@@ -46,7 +47,8 @@ func Test_deduplicateReleaseChangelog(t *testing.T) {
 							Kind:        KindAdded,
 						},
 					},
-					version: "2.0.0",
+					timestamp: "2018-05-12T12:00:00.000000Z",
+					version:   "2.0.0",
 				},
 				{
 					changelogs: []Changelog{
@@ -56,7 +58,8 @@ func Test_deduplicateReleaseChangelog(t *testing.T) {
 							Kind:        KindAdded,
 						},
 					},
-					version: "3.0.0",
+					timestamp: "2018-05-22T12:00:00.000000Z",
+					version:   "3.0.0",
 				},
 			},
 			expectedReleases: []Release{
@@ -68,7 +71,8 @@ func Test_deduplicateReleaseChangelog(t *testing.T) {
 							Kind:        KindAdded,
 						},
 					},
-					version: "1.0.0",
+					timestamp: "2018-05-02T12:00:00.000000Z",
+					version:   "1.0.0",
 				},
 				{
 					changelogs: []Changelog{
@@ -78,7 +82,8 @@ func Test_deduplicateReleaseChangelog(t *testing.T) {
 							Kind:        KindAdded,
 						},
 					},
-					version: "2.0.0",
+					timestamp: "2018-05-12T12:00:00.000000Z",
+					version:   "2.0.0",
 				},
 				{
 					changelogs: []Changelog{
@@ -88,7 +93,8 @@ func Test_deduplicateReleaseChangelog(t *testing.T) {
 							Kind:        KindAdded,
 						},
 					},
-					version: "3.0.0",
+					timestamp: "2018-05-22T12:00:00.000000Z",
+					version:   "3.0.0",
 				},
 			},
 		},
@@ -103,7 +109,8 @@ func Test_deduplicateReleaseChangelog(t *testing.T) {
 							Kind:        KindAdded,
 						},
 					},
-					version: "1.0.0",
+					timestamp: "2018-05-02T12:00:00.000000Z",
+					version:   "1.0.0",
 				},
 				{
 					changelogs: []Changelog{
@@ -118,7 +125,8 @@ func Test_deduplicateReleaseChangelog(t *testing.T) {
 							Kind:        KindChanged,
 						},
 					},
-					version: "1.0.1",
+					timestamp: "2018-05-18T12:00:00.000000Z",
+					version:   "1.0.1",
 				},
 				{
 					changelogs: []Changelog{
@@ -128,7 +136,8 @@ func Test_deduplicateReleaseChangelog(t *testing.T) {
 							Kind:        KindAdded,
 						},
 					},
-					version: "3.0.0",
+					timestamp: "2018-05-22T12:00:00.000000Z",
+					version:   "3.0.0",
 				},
 			},
 			expectedReleases: []Release{
@@ -140,7 +149,8 @@ func Test_deduplicateReleaseChangelog(t *testing.T) {
 							Kind:        KindAdded,
 						},
 					},
-					version: "1.0.0",
+					timestamp: "2018-05-02T12:00:00.000000Z",
+					version:   "1.0.0",
 				},
 				{
 					changelogs: []Changelog{
@@ -150,7 +160,8 @@ func Test_deduplicateReleaseChangelog(t *testing.T) {
 							Kind:        KindChanged,
 						},
 					},
-					version: "1.0.1",
+					timestamp: "2018-05-18T12:00:00.000000Z",
+					version:   "1.0.1",
 				},
 				{
 					changelogs: []Changelog{
@@ -160,7 +171,8 @@ func Test_deduplicateReleaseChangelog(t *testing.T) {
 							Kind:        KindAdded,
 						},
 					},
-					version: "3.0.0",
+					timestamp: "2018-05-22T12:00:00.000000Z",
+					version:   "3.0.0",
 				},
 			},
 		},
@@ -180,7 +192,8 @@ func Test_deduplicateReleaseChangelog(t *testing.T) {
 							Kind:        KindAdded,
 						},
 					},
-					version: "1.0.0",
+					timestamp: "2018-05-02T12:00:00.000000Z",
+					version:   "1.0.0",
 				},
 				{
 					changelogs: []Changelog{
@@ -195,13 +208,14 @@ func Test_deduplicateReleaseChangelog(t *testing.T) {
 							Kind:        KindChanged,
 						},
 					},
-					version: "1.0.1",
+					timestamp: "2018-05-28T12:00:00.000000Z",
+					version:   "1.0.1",
 				},
 				{
 					changelogs: []Changelog{
 						{
 							Component:   "foo-operator",
-							Description: "new feature z",
+							Description: "new feature x",
 							Kind:        KindAdded,
 						},
 						{
@@ -215,13 +229,14 @@ func Test_deduplicateReleaseChangelog(t *testing.T) {
 							Kind:        KindAdded,
 						},
 					},
-					version: "2.0.0",
+					timestamp: "2018-05-22T12:00:00.000000Z",
+					version:   "2.0.0",
 				},
 				{
 					changelogs: []Changelog{
 						{
 							Component:   "foo-operator",
-							Description: "new feature z",
+							Description: "new feature x",
 							Kind:        KindAdded,
 						},
 						{
@@ -235,7 +250,8 @@ func Test_deduplicateReleaseChangelog(t *testing.T) {
 							Kind:        KindAdded,
 						},
 					},
-					version: "2.0.1",
+					timestamp: "2018-05-28T15:00:00.000000Z",
+					version:   "2.0.1",
 				},
 			},
 			expectedReleases: []Release{
@@ -266,11 +282,6 @@ func Test_deduplicateReleaseChangelog(t *testing.T) {
 				},
 				{
 					changelogs: []Changelog{
-						{
-							Component:   "bar-operator",
-							Description: "new feature y",
-							Kind:        KindAdded,
-						},
 						{
 							Component:   "baz-operator",
 							Description: "new feature quux",

--- a/release.go
+++ b/release.go
@@ -132,6 +132,17 @@ func (r Release) WIP() bool {
 	return r.wip
 }
 
+func (r *Release) removeChangelogEntry(clog Changelog) {
+	for i := 0; i < len(r.changelogs); i++ {
+		if clog == r.changelogs[i] {
+			r.changelogs = append(r.changelogs[:i], r.changelogs[i+1:]...)
+			break
+		}
+	}
+
+	return
+}
+
 func aggregateReleaseChangelogs(bundles []Bundle) ([]Changelog, error) {
 	var changelogs []Changelog
 

--- a/release_test.go
+++ b/release_test.go
@@ -2328,3 +2328,93 @@ func Test_Releases_GetNewestRelease(t *testing.T) {
 		}
 	}
 }
+
+func Test_Release_removeChangelogEntry(t *testing.T) {
+	testCases := []struct {
+		name              string
+		release           Release
+		changelogToRemove Changelog
+		expectedRelease   Release
+	}{
+		{
+			name:    "case 0: remove from empty list",
+			release: Release{},
+			changelogToRemove: Changelog{
+				Component:   "foo-operator",
+				Description: "changed bar",
+				Kind:        KindChanged,
+			},
+			expectedRelease: Release{},
+		},
+		{
+			name: "case 1: remove from list of one",
+			release: Release{
+				changelogs: []Changelog{
+					{
+						Component:   "foo-operator",
+						Description: "changed bar",
+						Kind:        KindChanged,
+					},
+				},
+			},
+			changelogToRemove: Changelog{
+				Component:   "foo-operator",
+				Description: "changed bar",
+				Kind:        KindChanged,
+			},
+			expectedRelease: Release{
+				changelogs: []Changelog{},
+			},
+		},
+		{
+			name: "case 2: remove from list of many",
+			release: Release{
+				changelogs: []Changelog{
+					{
+						Component:   "foo-operator",
+						Description: "changed bar",
+						Kind:        KindChanged,
+					},
+					{
+						Component:   "foo-operator",
+						Description: "added quux",
+						Kind:        KindAdded,
+					},
+					{
+						Component:   "bar-operator",
+						Description: "fixed bug",
+						Kind:        KindFixed,
+					},
+				},
+			},
+			changelogToRemove: Changelog{
+				Component:   "foo-operator",
+				Description: "changed bar",
+				Kind:        KindChanged,
+			},
+			expectedRelease: Release{
+				changelogs: []Changelog{
+					{
+						Component:   "foo-operator",
+						Description: "added quux",
+						Kind:        KindAdded,
+					},
+					{
+						Component:   "bar-operator",
+						Description: "fixed bug",
+						Kind:        KindFixed,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.release.removeChangelogEntry(tc.changelogToRemove)
+			if !reflect.DeepEqual(tc.release, tc.expectedRelease) {
+				t.Fatalf("got %#v, expected %#v", tc.release, tc.expectedRelease)
+			}
+		})
+	}
+}


### PR DESCRIPTION
To replace earlier release aggregation, implement release compilation
based on defined release index and available version bundles.

CompileReleases() creates canonicalized collection of releases.

Towards https://github.com/giantswarm/giantswarm/issues/3047