### PR TITLE
Fix sorting by version in bundles and releases

### DIFF
--- a/bundles_sort.go
+++ b/bundles_sort.go
@@ -1,5 +1,7 @@
 package versionbundle
 
+import "github.com/coreos/go-semver/semver"
+
 type SortBundlesByName []Bundle
 
 func (b SortBundlesByName) Len() int           { return len(b) }
@@ -8,9 +10,13 @@ func (b SortBundlesByName) Less(i, j int) bool { return b[i].Name < b[j].Name }
 
 type SortBundlesByVersion []Bundle
 
-func (b SortBundlesByVersion) Len() int           { return len(b) }
-func (b SortBundlesByVersion) Swap(i, j int)      { b[i], b[j] = b[j], b[i] }
-func (b SortBundlesByVersion) Less(i, j int) bool { return b[i].Version < b[j].Version }
+func (b SortBundlesByVersion) Len() int      { return len(b) }
+func (b SortBundlesByVersion) Swap(i, j int) { b[i], b[j] = b[j], b[i] }
+func (b SortBundlesByVersion) Less(i, j int) bool {
+	verA := semver.New(b[i].Version)
+	verB := semver.New(b[j].Version)
+	return verA.LessThan(*verB)
+}
 
 type SortBundlesByTime []Bundle
 

--- a/bundles_sort_test.go
+++ b/bundles_sort_test.go
@@ -1,0 +1,95 @@
+package versionbundle
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestBundlesSortByVersion(t *testing.T) {
+	testCases := []struct {
+		name          string
+		bundles       []Bundle
+		expectedOrder []Bundle
+	}{
+		{
+			name: "case 0: sort 1.0.0, 2.0.0, 3.0.0",
+			bundles: []Bundle{
+				{
+					Version: "2.0.0",
+				},
+				{
+					Version: "1.0.0",
+				},
+				{
+					Version: "3.0.0",
+				},
+			},
+			expectedOrder: []Bundle{
+				{
+					Version: "1.0.0",
+				},
+				{
+					Version: "2.0.0",
+				},
+				{
+					Version: "3.0.0",
+				},
+			},
+		},
+		{
+			name: "case 1: sort 1.0.0, 1.10.1, 1.2.10",
+			bundles: []Bundle{
+				{
+					Version: "1.10.1",
+				},
+				{
+					Version: "1.0.0",
+				},
+				{
+					Version: "1.2.10",
+				},
+			},
+			expectedOrder: []Bundle{
+				{
+					Version: "1.0.0",
+				},
+				{
+					Version: "1.2.10",
+				},
+				{
+					Version: "1.10.1",
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			sort.Sort(SortBundlesByVersion(tc.bundles))
+			if !reflect.DeepEqual(tc.bundles, tc.expectedOrder) {
+				expectedOrderMsg := "["
+				for _, b := range tc.expectedOrder {
+					if len(expectedOrderMsg) > 1 {
+						expectedOrderMsg += ", "
+					}
+
+					expectedOrderMsg += b.Version
+				}
+
+				expectedOrderMsg += "]"
+
+				gotOrderMsg := "["
+				for _, b := range tc.bundles {
+					if len(gotOrderMsg) > 1 {
+						gotOrderMsg += ", "
+					}
+					gotOrderMsg += b.Version
+				}
+				gotOrderMsg += "]"
+
+				t.Fatalf("expected order: %s, got: %s", expectedOrderMsg, gotOrderMsg)
+			}
+		})
+	}
+}

--- a/releases_sort.go
+++ b/releases_sort.go
@@ -1,12 +1,20 @@
 package versionbundle
 
-import "time"
+import (
+	"time"
+
+	"github.com/coreos/go-semver/semver"
+)
 
 type SortReleasesByVersion []Release
 
-func (r SortReleasesByVersion) Len() int           { return len(r) }
-func (r SortReleasesByVersion) Swap(i, j int)      { r[i], r[j] = r[j], r[i] }
-func (r SortReleasesByVersion) Less(i, j int) bool { return r[i].Version() < r[j].Version() }
+func (r SortReleasesByVersion) Len() int      { return len(r) }
+func (r SortReleasesByVersion) Swap(i, j int) { r[i], r[j] = r[j], r[i] }
+func (r SortReleasesByVersion) Less(i, j int) bool {
+	verA := semver.New(r[i].Version())
+	verB := semver.New(r[j].Version())
+	return verA.LessThan(*verB)
+}
 
 type SortReleasesByTimestamp []Release
 

--- a/releases_sort_test.go
+++ b/releases_sort_test.go
@@ -1,0 +1,95 @@
+package versionbundle
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestReleasesSortByVersion(t *testing.T) {
+	testCases := []struct {
+		name          string
+		releases      []Release
+		expectedOrder []Release
+	}{
+		{
+			name: "case 0: sort 1.0.0, 2.0.0, 3.0.0",
+			releases: []Release{
+				{
+					version: "2.0.0",
+				},
+				{
+					version: "1.0.0",
+				},
+				{
+					version: "3.0.0",
+				},
+			},
+			expectedOrder: []Release{
+				{
+					version: "1.0.0",
+				},
+				{
+					version: "2.0.0",
+				},
+				{
+					version: "3.0.0",
+				},
+			},
+		},
+		{
+			name: "case 1: sort 1.0.0, 1.10.1, 1.2.10",
+			releases: []Release{
+				{
+					version: "1.10.1",
+				},
+				{
+					version: "1.0.0",
+				},
+				{
+					version: "1.2.10",
+				},
+			},
+			expectedOrder: []Release{
+				{
+					version: "1.0.0",
+				},
+				{
+					version: "1.2.10",
+				},
+				{
+					version: "1.10.1",
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			sort.Sort(SortReleasesByVersion(tc.releases))
+			if !reflect.DeepEqual(tc.releases, tc.expectedOrder) {
+				expectedOrderMsg := "["
+				for _, b := range tc.expectedOrder {
+					if len(expectedOrderMsg) > 1 {
+						expectedOrderMsg += ", "
+					}
+
+					expectedOrderMsg += b.version
+				}
+
+				expectedOrderMsg += "]"
+
+				gotOrderMsg := "["
+				for _, b := range tc.releases {
+					if len(gotOrderMsg) > 1 {
+						gotOrderMsg += ", "
+					}
+					gotOrderMsg += b.version
+				}
+				gotOrderMsg += "]"
+
+				t.Fatalf("expected order: %s, got: %s", expectedOrderMsg, gotOrderMsg)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Initial implementation used string sort for version sorting, but it
doesn't work correctly when comparing e.g. `1.2.0` and `1.10.0`. Use
`coreos/go-semver` implementation to properly compare versions when
sorting. This has performance penalty, but this can be optimized later
if necessary. First target is correct functionality.