### PR TITLE
Move Active() logic to NewRelease() and respect active flag in Active()

### DIFF
--- a/release.go
+++ b/release.go
@@ -88,6 +88,7 @@ func NewRelease(config ReleaseConfig) (Release, error) {
 	}
 
 	r := Release{
+		active:     !(deprecated || wip),
 		bundles:    config.Bundles,
 		changelogs: changelogs,
 		components: components,
@@ -101,7 +102,7 @@ func NewRelease(config ReleaseConfig) (Release, error) {
 }
 
 func (r Release) Active() bool {
-	return !(r.Deprecated() || r.WIP())
+	return r.active
 }
 
 func (r Release) Bundles() []Bundle {

--- a/release_test.go
+++ b/release_test.go
@@ -8,46 +8,71 @@ import (
 
 func Test_Release_Active(t *testing.T) {
 	testCases := []struct {
-		Release        Release
+		Bundles        []Bundle
 		ExpectedActive bool
 	}{
 		// Test 0: A release that is not WIP and not Deprecated should be considered Active
 		{
-			Release: Release{
-				wip:        false,
-				deprecated: false,
+			Bundles: []Bundle{
+				{
+					Name:       "bundle-a",
+					Version:    "1.0.0",
+					Deprecated: false,
+					WIP:        false,
+				},
 			},
 			ExpectedActive: true,
 		},
 		// Test 1: A release that is WIP but not Deprecated should not be considered Active
 		{
-			Release: Release{
-				wip:        true,
-				deprecated: false,
+			Bundles: []Bundle{
+				{
+					Name:       "bundle-a",
+					Version:    "1.0.0",
+					Deprecated: false,
+					WIP:        true,
+				},
 			},
 			ExpectedActive: false,
 		},
 		// Test 2: A release that is not WIP but is Deprecated should not be considered Active
 		{
-			Release: Release{
-				wip:        false,
-				deprecated: true,
+			Bundles: []Bundle{
+				{
+					Name:       "bundle-a",
+					Version:    "1.0.0",
+					Deprecated: true,
+					WIP:        false,
+				},
 			},
 			ExpectedActive: false,
 		},
 		// Test 3: A release that is WIP and Deprecated should not be considered Active
 		{
-			Release: Release{
-				wip:        true,
-				deprecated: true,
+			Bundles: []Bundle{
+				{
+					Name:       "bundle-a",
+					Version:    "1.0.0",
+					Deprecated: true,
+					WIP:        true,
+				},
 			},
 			ExpectedActive: false,
 		},
 	}
 
 	for i, tc := range testCases {
-		if tc.Release.Active() != tc.ExpectedActive {
-			t.Fatalf("test %d: We expected a release to be 'active: %v' but got 'active: %v'", i, tc.ExpectedActive, tc.Release.Active())
+		rc := ReleaseConfig{
+			Bundles: tc.Bundles,
+		}
+
+		release, err := NewRelease(rc)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if release.Active() != tc.ExpectedActive {
+			t.Fatalf("test %d: We expected a release to be 'active: %v' but got 'active: %v'", i, tc.ExpectedActive, release.Active())
 		}
 	}
 }

--- a/releases_test.go
+++ b/releases_test.go
@@ -122,17 +122,19 @@ func Test_deduplicateReleases(t *testing.T) {
 			name: "case 4: test with two Releases with same version where older is active",
 			input: []Release{
 				{
+					active:    false,
 					timestamp: time.Date(2018, time.February, 8, 0, 0, 00, 0, time.UTC),
 					version:   "1.1.1",
-					wip:       true,
 				},
 				{
+					active:    true,
 					timestamp: time.Date(2018, time.February, 2, 0, 0, 00, 0, time.UTC),
 					version:   "1.1.1",
 				},
 			},
 			expectedOutput: []Release{
 				{
+					active:    true,
 					timestamp: time.Date(2018, time.February, 2, 0, 0, 00, 0, time.UTC),
 					version:   "1.1.1",
 				},
@@ -145,6 +147,7 @@ func Test_deduplicateReleases(t *testing.T) {
 					timestamp:  time.Date(2018, time.February, 8, 0, 0, 00, 0, time.UTC),
 					version:    "1.1.1",
 					deprecated: true,
+					active:     false,
 				},
 				{
 					timestamp: time.Date(2018, time.March, 22, 0, 0, 00, 0, time.UTC),
@@ -160,10 +163,12 @@ func Test_deduplicateReleases(t *testing.T) {
 					timestamp: time.Date(2018, time.February, 18, 0, 0, 00, 0, time.UTC),
 					version:   "1.1.1",
 					wip:       true,
+					active:    false,
 				},
 				{
 					timestamp: time.Date(2018, time.February, 12, 0, 0, 00, 0, time.UTC),
 					version:   "1.1.1",
+					active:    true,
 				},
 			},
 			expectedOutput: []Release{
@@ -175,6 +180,7 @@ func Test_deduplicateReleases(t *testing.T) {
 				{
 					timestamp: time.Date(2018, time.February, 12, 0, 0, 00, 0, time.UTC),
 					version:   "1.1.1",
+					active:    true,
 				},
 				{
 					timestamp: time.Date(2018, time.March, 22, 0, 0, 00, 0, time.UTC),


### PR DESCRIPTION
When building Releases from IndexReleases, Release.active flag is
directly copied from IndexRelease as IndexRelease doesn't have WIP &
Deprecated concept anymore. To be compatible with old behavior, set
active flag with old logic when constructing in NewRelease().
CompileReleases() can then override this behavior when copying the flag
from IndexRelease.