### PR TITLE
Add bundle to release components

### DIFF
--- a/components_sort.go
+++ b/components_sort.go
@@ -1,0 +1,7 @@
+package versionbundle
+
+type SortComponentsByName []Component
+
+func (c SortComponentsByName) Len() int           { return len(c) }
+func (c SortComponentsByName) Swap(i, j int)      { c[i], c[j] = c[j], c[i] }
+func (c SortComponentsByName) Less(i, j int) bool { return c[i].Name < c[j].Name }

--- a/index_release_test.go
+++ b/index_release_test.go
@@ -195,6 +195,20 @@ func Test_buildReleases(t *testing.T) {
 							Kind:        KindAdded,
 						},
 					},
+					components: []Component{
+						{
+							Name:    "cert-operator",
+							Version: "0.1.0",
+						},
+						{
+							Name:    "cluster-operator",
+							Version: "0.1.0",
+						},
+						{
+							Name:    "kvm-operator",
+							Version: "2.2.1",
+						},
+					},
 					timestamp: time.Date(2018, time.April, 16, 12, 0, 0, 0, time.UTC),
 					version:   "1.0.0",
 				},
@@ -389,6 +403,20 @@ func Test_buildReleases(t *testing.T) {
 							Kind:        KindAdded,
 						},
 					},
+					components: []Component{
+						{
+							Name:    "cert-operator",
+							Version: "0.1.0",
+						},
+						{
+							Name:    "cluster-operator",
+							Version: "0.1.0",
+						},
+						{
+							Name:    "kvm-operator",
+							Version: "2.2.1",
+						},
+					},
 					timestamp: time.Date(2018, time.April, 16, 12, 0, 0, 0, time.UTC),
 					version:   "1.0.0",
 				},
@@ -446,6 +474,20 @@ func Test_buildReleases(t *testing.T) {
 							Component:   "kvm-operator",
 							Description: "New component q.",
 							Kind:        KindAdded,
+						},
+					},
+					components: []Component{
+						{
+							Name:    "cert-operator",
+							Version: "0.1.0",
+						},
+						{
+							Name:    "cluster-operator",
+							Version: "0.2.0",
+						},
+						{
+							Name:    "kvm-operator",
+							Version: "2.2.1",
 						},
 					},
 					timestamp: time.Date(2018, time.April, 22, 12, 0, 0, 0, time.UTC),
@@ -640,6 +682,20 @@ func Test_buildReleases(t *testing.T) {
 							Component:   "kvm-operator",
 							Description: "New component q.",
 							Kind:        KindAdded,
+						},
+					},
+					components: []Component{
+						{
+							Name:    "cert-operator",
+							Version: "0.1.0",
+						},
+						{
+							Name:    "cluster-operator",
+							Version: "0.1.0",
+						},
+						{
+							Name:    "kvm-operator",
+							Version: "2.2.1",
 						},
 					},
 					timestamp: time.Date(2018, time.April, 16, 12, 0, 0, 0, time.UTC),

--- a/release.go
+++ b/release.go
@@ -114,8 +114,15 @@ func aggregateReleaseComponents(bundles []Bundle) ([]Component, error) {
 	var components []Component
 
 	for _, b := range bundles {
+		bundleAsComponent := Component{
+			Name:    b.Name,
+			Version: b.Version,
+		}
+		components = append(components, bundleAsComponent)
 		components = append(components, b.Components...)
 	}
+
+	sort.Sort(SortComponentsByName(components))
 
 	return components, nil
 }

--- a/release_test.go
+++ b/release_test.go
@@ -333,6 +333,10 @@ func Test_Release_Components(t *testing.T) {
 					Name:    "kube-dns",
 					Version: "1.0.0",
 				},
+				{
+					Name:    "kubernetes-operator",
+					Version: "0.0.1",
+				},
 			},
 			ErrorMatcher: nil,
 		},
@@ -358,12 +362,16 @@ func Test_Release_Components(t *testing.T) {
 			},
 			ExpectedComponents: []Component{
 				{
+					Name:    "calico",
+					Version: "3.1.0",
+				},
+				{
 					Name:    "kube-dns",
 					Version: "1.17.0",
 				},
 				{
-					Name:    "calico",
-					Version: "3.1.0",
+					Name:    "kubernetes-operator",
+					Version: "11.4.1",
 				},
 			},
 			ErrorMatcher: nil,
@@ -432,16 +440,24 @@ func Test_Release_Components(t *testing.T) {
 					Version: "1.1.0",
 				},
 				{
-					Name:    "kube-dns",
-					Version: "1.0.0",
+					Name:    "cloud-config-operator",
+					Version: "0.2.0",
 				},
 				{
 					Name:    "etcd",
 					Version: "3.2.0",
 				},
 				{
+					Name:    "kube-dns",
+					Version: "1.0.0",
+				},
+				{
 					Name:    "kubernetes",
 					Version: "1.7.1",
+				},
+				{
+					Name:    "kubernetes-operator",
+					Version: "0.1.0",
 				},
 			},
 			ErrorMatcher: nil,
@@ -505,20 +521,28 @@ func Test_Release_Components(t *testing.T) {
 			},
 			ExpectedComponents: []Component{
 				{
+					Name:    "calico",
+					Version: "1.1.0",
+				},
+				{
+					Name:    "cloud-config-operator",
+					Version: "0.2.0",
+				},
+				{
 					Name:    "etcd",
 					Version: "3.2.0",
+				},
+				{
+					Name:    "kube-dns",
+					Version: "1.0.0",
 				},
 				{
 					Name:    "kubernetes",
 					Version: "1.7.1",
 				},
 				{
-					Name:    "calico",
-					Version: "1.1.0",
-				},
-				{
-					Name:    "kube-dns",
-					Version: "1.0.0",
+					Name:    "kubernetes-operator",
+					Version: "0.1.0",
 				},
 			},
 			ErrorMatcher: nil,


### PR DESCRIPTION
In order to expose version bundles that form a release, add them as
release components so that they are visible for end users.