### PR TITLE
Add validation for duplicate release dates in IndexReleases

### DIFF
--- a/index_release.go
+++ b/index_release.go
@@ -158,7 +158,8 @@ func mapReleaseChangelogs(r Release) map[string]struct{} {
 	return changelogs
 }
 
-// TODO define and implement validation rules
+// ValidateIndexReleases ensures semantic rules for collection of indexReleases
+// so that when used together, they form consistent and integral release index.
 func ValidateIndexReleases(indexReleases []IndexRelease) error {
 	if len(indexReleases) == 0 {
 		return nil
@@ -206,10 +207,18 @@ func validateReleaseAuthorities(indexReleases []IndexRelease) error {
 }
 
 func validateReleaseDates(indexReleases []IndexRelease) error {
+	releaseDates := make(map[time.Time]string)
 	for _, release := range indexReleases {
 		if release.Date.IsZero() {
 			return microerror.Maskf(invalidReleaseError, "release %s has empty release date", release.Version)
 		}
+
+		ver, exists := releaseDates[release.Date]
+		if exists {
+			return microerror.Maskf(invalidReleaseError, "releases %s and %s have duplicate release dates", ver, release.Version)
+		}
+
+		releaseDates[release.Date] = release.Version
 	}
 
 	return nil

--- a/index_release_test.go
+++ b/index_release_test.go
@@ -1666,6 +1666,28 @@ func Test_validateReleaseDates(t *testing.T) {
 			},
 			errorMatcher: IsInvalidRelease,
 		},
+		{
+			name: "case 4: failure with duplicate release date in two releases",
+			releases: []IndexRelease{
+				{
+					Date:    time.Date(2018, time.May, 21, 13, 12, 00, 00, time.UTC),
+					Version: "4.0.0",
+				},
+				{
+					Date:    time.Date(2018, time.May, 20, 13, 12, 00, 00, time.UTC),
+					Version: "3.0.0",
+				},
+				{
+					Date:    time.Date(2018, time.May, 20, 13, 12, 00, 00, time.UTC),
+					Version: "2.0.0",
+				},
+				{
+					Date:    time.Date(2018, time.May, 19, 13, 12, 00, 00, time.UTC),
+					Version: "1.0.0",
+				},
+			},
+			errorMatcher: IsInvalidRelease,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Changelog deduplication is processed by sorting releases by version and
release date. If release date is duplicate for consecutive releases, the
algorithm cannot find correct previous release to compare changelogs
against. Therefore release dates must be unique, which they practically
always are in the real life as well.