### PR TITLE
remove duplicate release date check

### DIFF
--- a/index_release.go
+++ b/index_release.go
@@ -213,11 +213,6 @@ func validateReleaseDates(indexReleases []IndexRelease) error {
 			return microerror.Maskf(invalidReleaseError, "release %s has empty release date", release.Version)
 		}
 
-		ver, exists := releaseDates[release.Date]
-		if exists {
-			return microerror.Maskf(invalidReleaseError, "releases %s and %s have duplicate release dates", ver, release.Version)
-		}
-
 		releaseDates[release.Date] = release.Version
 	}
 

--- a/index_release_test.go
+++ b/index_release_test.go
@@ -1738,28 +1738,6 @@ func Test_validateReleaseDates(t *testing.T) {
 			},
 			errorMatcher: IsInvalidRelease,
 		},
-		{
-			name: "case 4: failure with duplicate release date in two releases",
-			releases: []IndexRelease{
-				{
-					Date:    time.Date(2018, time.May, 21, 13, 12, 00, 00, time.UTC),
-					Version: "4.0.0",
-				},
-				{
-					Date:    time.Date(2018, time.May, 20, 13, 12, 00, 00, time.UTC),
-					Version: "3.0.0",
-				},
-				{
-					Date:    time.Date(2018, time.May, 20, 13, 12, 00, 00, time.UTC),
-					Version: "2.0.0",
-				},
-				{
-					Date:    time.Date(2018, time.May, 19, 13, 12, 00, 00, time.UTC),
-					Version: "1.0.0",
-				},
-			},
-			errorMatcher: IsInvalidRelease,
-		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
this is wrong. multiple releases can have the same date. eg if we create
security patch releases against multiple major versions.