### PR TITLE
pass endpoint as arguments instead of config

### DIFF
--- a/collector_test.go
+++ b/collector_test.go
@@ -553,8 +553,6 @@ func Test_Collector_Collect(t *testing.T) {
 				FilterFunc: tc.FilterFunc,
 				Logger:     microloggertest.New(),
 				RestClient: resty.New(),
-
-				Endpoints: endpoints,
 			}
 
 			collector, err = NewCollector(c)
@@ -568,7 +566,7 @@ func Test_Collector_Collect(t *testing.T) {
 			t.Fatalf("test %d expected %#v got %#v", i, nil, b1)
 		}
 
-		err = collector.Collect(context.TODO())
+		err = collector.Collect(context.TODO(), endpoints)
 		if err != nil {
 			t.Fatalf("test %d expected %#v got %#v", i, nil, err)
 		}


### PR DESCRIPTION
Towards: giantswarm/giantswarm#7310

Instead of passing `endpoints` via the Config and using `SetEndpoints` to change this over time, let's just pass `endpoints` as argument to the `Collect` function.

This is only used in `cluster-service` and should not break any other code.