### PR TITLE
versionbundle: allow pre-release versions

### DIFF
--- a/bundle.go
+++ b/bundle.go
@@ -172,21 +172,9 @@ func (b Bundle) Validate() error {
 		return microerror.Maskf(invalidBundleError, "name must not be empty")
 	}
 
-	versionSplit := strings.Split(b.Version, ".")
-	if len(versionSplit) != 3 {
-		return microerror.Maskf(invalidBundleError, "version format must be '<major>.<minor>.<patch>'")
-	}
-
-	if !isPositiveNumber(versionSplit[0]) {
-		return microerror.Maskf(invalidBundleError, "major version must be positive number")
-	}
-
-	if !isPositiveNumber(versionSplit[1]) {
-		return microerror.Maskf(invalidBundleError, "minor version must be positive number")
-	}
-
-	if !isPositiveNumber(versionSplit[2]) {
-		return microerror.Maskf(invalidBundleError, "patch version must be positive number")
+	_, err := semver.NewVersion(b.Version)
+	if err != nil {
+		return microerror.Maskf(invalidBundleError, "version parsing failed with error %#q", err)
 	}
 
 	return nil

--- a/bundles_test.go
+++ b/bundles_test.go
@@ -1318,7 +1318,25 @@ func Test_Bundles_Validate(t *testing.T) {
 			ErrorMatcher: IsInvalidBundlesError,
 		},
 
-		// Test 3 is the same as 2 but with multiple version bundles.
+		// Test 3 ensures a bundle with pre-release version is valid.
+		{
+			Bundles: []Bundle{
+				{
+					Changelogs: []Changelog{},
+					Components: []Component{
+						{
+							Name:    "calico",
+							Version: "1.1.0",
+						},
+					},
+					Name:    "kubernetes-operator",
+					Version: "0.1.0-pre-release",
+				},
+			},
+			ErrorMatcher: IsInvalidBundlesError,
+		},
+
+		// Test 4 is the same as 2 but with multiple version bundles.
 		{
 			Bundles: []Bundle{
 				{
@@ -1366,7 +1384,7 @@ func Test_Bundles_Validate(t *testing.T) {
 			ErrorMatcher: IsInvalidBundlesError,
 		},
 
-		// Test 4 ensures validation of a list of version bundles where a
+		// Test 5 ensures validation of a list of version bundles where a
 		// version bundle has no components does not throw an error.
 		{
 			Bundles: []Bundle{
@@ -1391,7 +1409,7 @@ func Test_Bundles_Validate(t *testing.T) {
 			ErrorMatcher: nil,
 		},
 
-		// Test 5 is the same as 4 but with multiple version bundles.
+		// Test 6 is the same as 4 but with multiple version bundles.
 		{
 			Bundles: []Bundle{
 				{
@@ -1441,7 +1459,7 @@ func Test_Bundles_Validate(t *testing.T) {
 			ErrorMatcher: nil,
 		},
 
-		// Test 6 ensures validation of a list of version bundles having the
+		// Test 7 ensures validation of a list of version bundles having the
 		// different name and version not throws an error.
 		{
 			Bundles: []Bundle{
@@ -1491,7 +1509,7 @@ func Test_Bundles_Validate(t *testing.T) {
 			ErrorMatcher: nil,
 		},
 
-		// Test 7 ensures validation of a list of version bundles having duplicated
+		// Test 8 ensures validation of a list of version bundles having duplicated
 		// version bundles throws an error.
 		{
 			Bundles: []Bundle{
@@ -1541,7 +1559,7 @@ func Test_Bundles_Validate(t *testing.T) {
 			ErrorMatcher: IsInvalidBundlesError,
 		},
 
-		// Test 8 ensures validation of a list of version bundles having the same
+		// Test 9 ensures validation of a list of version bundles having the same
 		// version throws an error.
 		{
 			Bundles: []Bundle{
@@ -1591,7 +1609,7 @@ func Test_Bundles_Validate(t *testing.T) {
 			ErrorMatcher: IsInvalidBundlesError,
 		},
 
-		// Test 9 verifies that version increment is validated per provider.
+		// Test 10 verifies that version increment is validated per provider.
 		{
 			Bundles: []Bundle{
 				{
@@ -1652,7 +1670,7 @@ func Test_Bundles_Validate(t *testing.T) {
 			ErrorMatcher: nil,
 		},
 
-		// Test 10 like test 9 but verifies invalidBundlesError when there are
+		// Test 11 like test 10 but verifies invalidBundlesError when there are
 		// two Bundles for AWS provider and second of those has newer timestamp
 		// and lower version number.
 		{

--- a/component.go
+++ b/component.go
@@ -2,8 +2,8 @@ package versionbundle
 
 import (
 	"encoding/json"
-	"strings"
 
+	"github.com/coreos/go-semver/semver"
 	"github.com/giantswarm/microerror"
 )
 
@@ -26,21 +26,9 @@ func (c Component) Validate() error {
 		return microerror.Maskf(invalidComponentError, "version must not be empty")
 	}
 
-	versionSplit := strings.Split(c.Version, ".")
-	if len(versionSplit) != 3 {
-		return microerror.Maskf(invalidComponentError, "version format must be '<major>.<minor>.<patch>'")
-	}
-
-	if !isPositiveNumber(versionSplit[0]) {
-		return microerror.Maskf(invalidComponentError, "major version must be positive number")
-	}
-
-	if !isPositiveNumber(versionSplit[1]) {
-		return microerror.Maskf(invalidComponentError, "minor version must be positive number")
-	}
-
-	if !isPositiveNumber(versionSplit[2]) {
-		return microerror.Maskf(invalidComponentError, "patch version must be positive number")
+	_, err := semver.NewVersion(c.Version)
+	if err != nil {
+		return microerror.Maskf(invalidComponentError, "version parsing failed with error %#q", err)
 	}
 
 	return nil

--- a/component_test.go
+++ b/component_test.go
@@ -202,6 +202,14 @@ func Test_Component_Validate(t *testing.T) {
 			},
 			ErrorMatcher: nil,
 		},
+		// Test 21 ensures a component with pre-release version is valid.
+		{
+			Component: Component{
+				Name:    "kubernetes",
+				Version: "11.3.785-pre-release",
+			},
+			ErrorMatcher: nil,
+		},
 	}
 
 	for i, tc := range testCases {


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/7511

`github.com/coreos/go-semver/semver` library was already in use `*_sort.go` files.