### PR TITLE
Add apps on release struct

### DIFF
--- a/app.go
+++ b/app.go
@@ -1,7 +1,5 @@
 package versionbundle
 
-import "encoding/json"
-
 type App struct {
 	App              string `yaml:"app"`
 	ComponentVersion string `yaml:"componentVersion"`
@@ -9,16 +7,7 @@ type App struct {
 }
 
 func CopyApps(apps []App) []App {
-	raw, err := json.Marshal(apps)
-	if err != nil {
-		panic(err)
-	}
-
-	var appList []App
-	err = json.Unmarshal(raw, &appList)
-	if err != nil {
-		panic(err)
-	}
-
+	appList := make([]App, len(apps))
+	copy(appList, apps)
 	return appList
 }

--- a/app.go
+++ b/app.go
@@ -1,0 +1,24 @@
+package versionbundle
+
+import "encoding/json"
+
+type App struct {
+	App              string `yaml:"app"`
+	ComponentVersion string `yaml:"componentVersion"`
+	Version          string `yaml:"version"`
+}
+
+func CopyApps(apps []App) []App {
+	raw, err := json.Marshal(apps)
+	if err != nil {
+		panic(err)
+	}
+
+	var appList []App
+	err = json.Unmarshal(raw, &appList)
+	if err != nil {
+		panic(err)
+	}
+
+	return appList
+}

--- a/index_release.go
+++ b/index_release.go
@@ -55,6 +55,7 @@ func buildReleases(logger micrologger.Logger, indexReleases []IndexRelease, bund
 
 		rc := ReleaseConfig{
 			Active:  ir.Active,
+			Apps:    ir.Apps,
 			Bundles: bundles,
 			Date:    ir.Date,
 			Version: ir.Version,

--- a/index_release.go
+++ b/index_release.go
@@ -12,10 +12,9 @@ import (
 	"github.com/giantswarm/micrologger"
 )
 
-const indexReleaseTimestampFormat = "2006-01-02T15:04:05.00Z"
-
 type IndexRelease struct {
 	Active      bool        `yaml:"active"`
+	Apps        []App       `yaml:"apps"`
 	Authorities []Authority `yaml:"authorities"`
 	Date        time.Time   `yaml:"date"`
 	Version     string      `yaml:"version"`

--- a/release.go
+++ b/release.go
@@ -12,12 +12,14 @@ const releaseTimestampFormat = "2006-01-02T15:04:05.000000Z"
 
 type ReleaseConfig struct {
 	Active  bool
+	Apps    []App
 	Bundles []Bundle
 	Date    time.Time
 	Version string
 }
 
 type Release struct {
+	apps       []App
 	bundles    []Bundle
 	changelogs []Changelog
 	components []Component
@@ -51,6 +53,7 @@ func NewRelease(config ReleaseConfig) (Release, error) {
 
 	r := Release{
 		active:     config.Active,
+		apps:       config.Apps,
 		bundles:    config.Bundles,
 		changelogs: changelogs,
 		components: components,
@@ -63,6 +66,10 @@ func NewRelease(config ReleaseConfig) (Release, error) {
 
 func (r Release) Active() bool {
 	return r.active
+}
+
+func (r Release) Apps() []App {
+	return CopyApps(r.apps)
 }
 
 func (r Release) Bundles() []Bundle {


### PR DESCRIPTION
Toward https://github.com/giantswarm/giantswarm/issues/8135

Including `apps` information on release information. I'll test this on cluster-service. 