### PR TITLE
Adding kind function to compile changelog from release

### DIFF
--- a/changelog.go
+++ b/changelog.go
@@ -77,13 +77,7 @@ func (c Changelog) Validate() error {
 		return microerror.Maskf(invalidChangelogError, "Kind must not be empty")
 	}
 
-	var found bool
-	for _, k := range validKinds {
-		if c.Kind == k {
-			found = true
-		}
-	}
-	if !found {
+	if !ValidateKind(c.Kind) {
 		return microerror.Maskf(invalidChangelogError, "Kind must be one of %#v", validKinds)
 	}
 
@@ -103,4 +97,13 @@ func CopyChangelogs(changelogs []Changelog) []Changelog {
 	}
 
 	return copy
+}
+
+func ValidateKind(v Kind) bool {
+	for _, k := range validKinds {
+		if v == k {
+			return true
+		}
+	}
+	return false
 }

--- a/changelog.go
+++ b/changelog.go
@@ -2,35 +2,36 @@ package versionbundle
 
 import (
 	"encoding/json"
+	"strings"
 
 	"github.com/giantswarm/microerror"
 )
 
-type Kind string
+type kind string
 
 const (
 	// KindAdded being used in a changelog describes an authority's component got
 	// added.
-	KindAdded Kind = "added"
+	KindAdded kind = "added"
 	// KindChanged being used in a changelog describes an authority's component got
 	// changed.
-	KindChanged Kind = "changed"
+	KindChanged kind = "changed"
 	// KindDeprecated being used in a changelog describes an authority's component got
 	// deprecated.
-	KindDeprecated Kind = "deprecated"
+	KindDeprecated kind = "deprecated"
 	// KindFixed being used in a changelog describes an authority's component got
 	// fixed.
-	KindFixed Kind = "fixed"
+	KindFixed kind = "fixed"
 	// KindRemoved being used in a changelog describes an authority's component got
 	// removed.
-	KindRemoved Kind = "removed"
+	KindRemoved kind = "removed"
 	// KindSecurity being used in a changelog describes an authority's component got
 	// adapted for security reasons.
-	KindSecurity Kind = "security"
+	KindSecurity kind = "security"
 )
 
 var (
-	validKinds = []Kind{
+	validKinds = []kind{
 		KindAdded,
 		KindChanged,
 		KindDeprecated,
@@ -52,9 +53,9 @@ type Changelog struct {
 	// Description is some text describing the changelog entry. This information
 	// is intended to be useful for humans.
 	Description string `json:"description" yaml:"description"`
-	// Kind is a machine readable type describing what Kind of changelog the
-	// changelog actually is. Also see the Kind type.
-	Kind Kind `json:"kind" yaml:"kind"`
+	// Kind is a machine readable type describing what kind of changelog the
+	// changelog actually is. Also see the kind type.
+	Kind kind `json:"kind" yaml:"kind"`
 	// URLs is a list of links which contain additional information to the
 	// changelog entry such as upstream changelogs or pull requests.
 	URLs []string `json:"urls" yaml:"urls"`
@@ -74,11 +75,17 @@ func (c Changelog) Validate() error {
 	}
 
 	if c.Kind == "" {
-		return microerror.Maskf(invalidChangelogError, "Kind must not be empty")
+		return microerror.Maskf(invalidChangelogError, "kind must not be empty")
 	}
 
-	if !ValidateKind(c.Kind) {
-		return microerror.Maskf(invalidChangelogError, "Kind must be one of %#v", validKinds)
+	var found bool
+	for _, k := range validKinds {
+		if c.Kind == k {
+			found = true
+		}
+	}
+	if !found {
+		return microerror.Maskf(invalidChangelogError, "kind must be one of %#v", validKinds)
 	}
 
 	return nil
@@ -99,11 +106,12 @@ func CopyChangelogs(changelogs []Changelog) []Changelog {
 	return copy
 }
 
-func ValidateKind(v Kind) bool {
+func NewKind(kindType string) (kind, error) {
+	converted := kind(strings.ToLower(kindType))
 	for _, k := range validKinds {
-		if v == k {
-			return true
+		if converted == k {
+			return converted, nil
 		}
 	}
-	return false
+	return kind(""), microerror.Maskf(invalidChangelogError, "kind must be one of %#v", validKinds)
 }

--- a/changelog.go
+++ b/changelog.go
@@ -2,8 +2,8 @@ package versionbundle
 
 import (
 	"encoding/json"
-
 	"github.com/giantswarm/microerror"
+	"strings"
 )
 
 type kind string
@@ -103,4 +103,14 @@ func CopyChangelogs(changelogs []Changelog) []Changelog {
 	}
 
 	return copy
+}
+
+func Kind(kindType string) (kind, error) {
+	converted := kind(strings.ToLower(kindType))
+	for _, k := range validKinds {
+		if converted == k {
+			return converted, nil
+		}
+	}
+	return kind(""), microerror.Maskf(invalidChangelogError, "kind must be one of %#v", validKinds)
 }

--- a/changelog.go
+++ b/changelog.go
@@ -113,5 +113,5 @@ func NewKind(kindType string) (kind, error) {
 			return converted, nil
 		}
 	}
-	return kind(""), microerror.Maskf(invalidChangelogError, "kind must be one of %#v", validKinds)
+	return kind(""), microerror.Maskf(executionFailedError, "kind must be one of %#v", validKinds)
 }

--- a/changelog.go
+++ b/changelog.go
@@ -2,8 +2,9 @@ package versionbundle
 
 import (
 	"encoding/json"
-	"github.com/giantswarm/microerror"
 	"strings"
+
+	"github.com/giantswarm/microerror"
 )
 
 type kind string

--- a/changelog.go
+++ b/changelog.go
@@ -2,36 +2,35 @@ package versionbundle
 
 import (
 	"encoding/json"
-	"strings"
 
 	"github.com/giantswarm/microerror"
 )
 
-type kind string
+type Kind string
 
 const (
 	// KindAdded being used in a changelog describes an authority's component got
 	// added.
-	KindAdded kind = "added"
+	KindAdded Kind = "added"
 	// KindChanged being used in a changelog describes an authority's component got
 	// changed.
-	KindChanged kind = "changed"
+	KindChanged Kind = "changed"
 	// KindDeprecated being used in a changelog describes an authority's component got
 	// deprecated.
-	KindDeprecated kind = "deprecated"
+	KindDeprecated Kind = "deprecated"
 	// KindFixed being used in a changelog describes an authority's component got
 	// fixed.
-	KindFixed kind = "fixed"
+	KindFixed Kind = "fixed"
 	// KindRemoved being used in a changelog describes an authority's component got
 	// removed.
-	KindRemoved kind = "removed"
+	KindRemoved Kind = "removed"
 	// KindSecurity being used in a changelog describes an authority's component got
 	// adapted for security reasons.
-	KindSecurity kind = "security"
+	KindSecurity Kind = "security"
 )
 
 var (
-	validKinds = []kind{
+	validKinds = []Kind{
 		KindAdded,
 		KindChanged,
 		KindDeprecated,
@@ -53,9 +52,9 @@ type Changelog struct {
 	// Description is some text describing the changelog entry. This information
 	// is intended to be useful for humans.
 	Description string `json:"description" yaml:"description"`
-	// Kind is a machine readable type describing what kind of changelog the
-	// changelog actually is. Also see the kind type.
-	Kind kind `json:"kind" yaml:"kind"`
+	// Kind is a machine readable type describing what Kind of changelog the
+	// changelog actually is. Also see the Kind type.
+	Kind Kind `json:"Kind" yaml:"Kind"`
 	// URLs is a list of links which contain additional information to the
 	// changelog entry such as upstream changelogs or pull requests.
 	URLs []string `json:"urls" yaml:"urls"`
@@ -75,7 +74,7 @@ func (c Changelog) Validate() error {
 	}
 
 	if c.Kind == "" {
-		return microerror.Maskf(invalidChangelogError, "kind must not be empty")
+		return microerror.Maskf(invalidChangelogError, "Kind must not be empty")
 	}
 
 	var found bool
@@ -85,7 +84,7 @@ func (c Changelog) Validate() error {
 		}
 	}
 	if !found {
-		return microerror.Maskf(invalidChangelogError, "kind must be one of %#v", validKinds)
+		return microerror.Maskf(invalidChangelogError, "Kind must be one of %#v", validKinds)
 	}
 
 	return nil
@@ -104,14 +103,4 @@ func CopyChangelogs(changelogs []Changelog) []Changelog {
 	}
 
 	return copy
-}
-
-func Kind(kindType string) (kind, error) {
-	converted := kind(strings.ToLower(kindType))
-	for _, k := range validKinds {
-		if converted == k {
-			return converted, nil
-		}
-	}
-	return kind(""), microerror.Maskf(invalidChangelogError, "kind must be one of %#v", validKinds)
 }

--- a/changelog.go
+++ b/changelog.go
@@ -54,7 +54,7 @@ type Changelog struct {
 	Description string `json:"description" yaml:"description"`
 	// Kind is a machine readable type describing what Kind of changelog the
 	// changelog actually is. Also see the Kind type.
-	Kind Kind `json:"Kind" yaml:"Kind"`
+	Kind Kind `json:"kind" yaml:"kind"`
 	// URLs is a list of links which contain additional information to the
 	// changelog entry such as upstream changelogs or pull requests.
 	URLs []string `json:"urls" yaml:"urls"`

--- a/changelog.go
+++ b/changelog.go
@@ -10,23 +10,17 @@ import (
 type kind string
 
 const (
-	// KindAdded being used in a changelog describes an authority's component got
-	// added.
+	// KindAdded is used in changelogs for new features.
 	KindAdded kind = "added"
-	// KindChanged being used in a changelog describes an authority's component got
-	// changed.
+	// KindChanged is used in changelogs for changes in existing functionality.
 	KindChanged kind = "changed"
-	// KindDeprecated being used in a changelog describes an authority's component got
-	// deprecated.
+	// KindDeprecated is used in a changelogs for soon-to-be removed features.
 	KindDeprecated kind = "deprecated"
-	// KindFixed being used in a changelog describes an authority's component got
-	// fixed.
+	// KindFixed is used in changelogs for any bug fixes.
 	KindFixed kind = "fixed"
-	// KindRemoved being used in a changelog describes an authority's component got
-	// removed.
+	// KindRemoved is used in changelogs for now removed features.
 	KindRemoved kind = "removed"
-	// KindSecurity being used in a changelog describes an authority's component got
-	// adapted for security reasons.
+	// KindSecurity is used in chnagelogs in case of vulnerabilities.
 	KindSecurity kind = "security"
 )
 

--- a/changelog_test.go
+++ b/changelog_test.go
@@ -25,7 +25,7 @@ func Test_Changelog_Validate(t *testing.T) {
 			ErrorMatcher: IsInvalidChangelog,
 		},
 
-		// Test 2 ensures a changelog missing description and Kind throws an error.
+		// Test 2 ensures a changelog missing description and kind throws an error.
 		{
 			Changelog: Changelog{
 				Component:   "kubernetes",
@@ -35,7 +35,7 @@ func Test_Changelog_Validate(t *testing.T) {
 			ErrorMatcher: IsInvalidChangelog,
 		},
 
-		// Test 2 ensures a changelog missing Kind throws an error.
+		// Test 2 ensures a changelog missing kind throws an error.
 		{
 			Changelog: Changelog{
 				Component:   "kubernetes",
@@ -45,7 +45,7 @@ func Test_Changelog_Validate(t *testing.T) {
 			ErrorMatcher: IsInvalidChangelog,
 		},
 
-		// Test 3 ensures a changelog missing a valid Kind throws an error.
+		// Test 3 ensures a changelog missing a valid kind throws an error.
 		{
 			Changelog: Changelog{
 				Component:   "kubernetes",
@@ -75,7 +75,7 @@ func Test_Changelog_Validate(t *testing.T) {
 			ErrorMatcher: IsInvalidChangelog,
 		},
 
-		// Test 6 ensures a changelog having a valid Kind does not throw an error.
+		// Test 6 ensures a changelog having a valid kind does not throw an error.
 		{
 			Changelog: Changelog{
 				Component:   "kubernetes",
@@ -85,7 +85,7 @@ func Test_Changelog_Validate(t *testing.T) {
 			ErrorMatcher: nil,
 		},
 
-		// Test 7 is the same as 6 but with a different Kind.
+		// Test 7 is the same as 6 but with a different kind.
 		{
 			Changelog: Changelog{
 				Component:   "kubernetes",
@@ -95,7 +95,7 @@ func Test_Changelog_Validate(t *testing.T) {
 			ErrorMatcher: nil,
 		},
 
-		// Test 8 is the same as 6 but with a different Kind.
+		// Test 8 is the same as 6 but with a different kind.
 		{
 			Changelog: Changelog{
 				Component:   "kubernetes",
@@ -105,7 +105,7 @@ func Test_Changelog_Validate(t *testing.T) {
 			ErrorMatcher: nil,
 		},
 
-		// Test 9 is the same as 6 but with a different Kind.
+		// Test 9 is the same as 6 but with a different kind.
 		{
 			Changelog: Changelog{
 				Component:   "kubernetes",
@@ -115,7 +115,7 @@ func Test_Changelog_Validate(t *testing.T) {
 			ErrorMatcher: nil,
 		},
 
-		// Test 10 is the same as 6 but with a different Kind.
+		// Test 10 is the same as 6 but with a different kind.
 		{
 			Changelog: Changelog{
 				Component:   "kubernetes",
@@ -125,7 +125,7 @@ func Test_Changelog_Validate(t *testing.T) {
 			ErrorMatcher: nil,
 		},
 
-		// Test 11 is the same as 6 but with a different Kind.
+		// Test 11 is the same as 6 but with a different kind.
 		{
 			Changelog: Changelog{
 				Component:   "kubernetes",

--- a/changelog_test.go
+++ b/changelog_test.go
@@ -25,7 +25,7 @@ func Test_Changelog_Validate(t *testing.T) {
 			ErrorMatcher: IsInvalidChangelog,
 		},
 
-		// Test 2 ensures a changelog missing description and kind throws an error.
+		// Test 2 ensures a changelog missing description and Kind throws an error.
 		{
 			Changelog: Changelog{
 				Component:   "kubernetes",
@@ -35,7 +35,7 @@ func Test_Changelog_Validate(t *testing.T) {
 			ErrorMatcher: IsInvalidChangelog,
 		},
 
-		// Test 2 ensures a changelog missing kind throws an error.
+		// Test 2 ensures a changelog missing Kind throws an error.
 		{
 			Changelog: Changelog{
 				Component:   "kubernetes",
@@ -45,7 +45,7 @@ func Test_Changelog_Validate(t *testing.T) {
 			ErrorMatcher: IsInvalidChangelog,
 		},
 
-		// Test 3 ensures a changelog missing a valid kind throws an error.
+		// Test 3 ensures a changelog missing a valid Kind throws an error.
 		{
 			Changelog: Changelog{
 				Component:   "kubernetes",
@@ -75,7 +75,7 @@ func Test_Changelog_Validate(t *testing.T) {
 			ErrorMatcher: IsInvalidChangelog,
 		},
 
-		// Test 6 ensures a changelog having a valid kind does not throw an error.
+		// Test 6 ensures a changelog having a valid Kind does not throw an error.
 		{
 			Changelog: Changelog{
 				Component:   "kubernetes",
@@ -85,7 +85,7 @@ func Test_Changelog_Validate(t *testing.T) {
 			ErrorMatcher: nil,
 		},
 
-		// Test 7 is the same as 6 but with a different kind.
+		// Test 7 is the same as 6 but with a different Kind.
 		{
 			Changelog: Changelog{
 				Component:   "kubernetes",
@@ -95,7 +95,7 @@ func Test_Changelog_Validate(t *testing.T) {
 			ErrorMatcher: nil,
 		},
 
-		// Test 8 is the same as 6 but with a different kind.
+		// Test 8 is the same as 6 but with a different Kind.
 		{
 			Changelog: Changelog{
 				Component:   "kubernetes",
@@ -105,7 +105,7 @@ func Test_Changelog_Validate(t *testing.T) {
 			ErrorMatcher: nil,
 		},
 
-		// Test 9 is the same as 6 but with a different kind.
+		// Test 9 is the same as 6 but with a different Kind.
 		{
 			Changelog: Changelog{
 				Component:   "kubernetes",
@@ -115,7 +115,7 @@ func Test_Changelog_Validate(t *testing.T) {
 			ErrorMatcher: nil,
 		},
 
-		// Test 10 is the same as 6 but with a different kind.
+		// Test 10 is the same as 6 but with a different Kind.
 		{
 			Changelog: Changelog{
 				Component:   "kubernetes",
@@ -125,7 +125,7 @@ func Test_Changelog_Validate(t *testing.T) {
 			ErrorMatcher: nil,
 		},
 
-		// Test 11 is the same as 6 but with a different kind.
+		// Test 11 is the same as 6 but with a different Kind.
 		{
 			Changelog: Changelog{
 				Component:   "kubernetes",


### PR DESCRIPTION
During implementing https://github.com/giantswarm/cluster-service/pull/409, 

I found we need to have a function for converting `changelog` type from `release`. 

Since `kind` type is private inside `versionbundle`, new function makes sense in here. 