### PR TITLE
New type for cluster-service usage

### DIFF
--- a/app_changelog.go
+++ b/app_changelog.go
@@ -1,0 +1,12 @@
+package versionbundle
+
+type AppsLog map[string][]Log
+
+type Log struct {
+	Description string   `json:"description"`
+	Type        string   `json:"type"`
+	Urls        []string `json:"urls"`
+	Version     string   `json:"version"`
+}
+
+type ReleasesLog map[string]AppsLog

--- a/app_changelog.go
+++ b/app_changelog.go
@@ -1,12 +1,5 @@
 package versionbundle
 
-type AppsChangelogs map[string][]AppChangelog
-
-type AppChangelog struct {
-	Description string   `json:"description"`
-	Type        string   `json:"type"`
-	Urls        []string `json:"urls"`
-	Version     string   `json:"version"`
-}
+type AppsChangelogs map[string][]Changelog
 
 type ReleasesChangelogs map[string]AppsChangelogs

--- a/app_changelog.go
+++ b/app_changelog.go
@@ -1,12 +1,12 @@
 package versionbundle
 
-type AppsLog map[string][]Log
+type AppsChangelogs map[string][]AppChangelog
 
-type Log struct {
+type AppChangelog struct {
 	Description string   `json:"description"`
 	Type        string   `json:"type"`
 	Urls        []string `json:"urls"`
 	Version     string   `json:"version"`
 }
 
-type ReleasesLog map[string]AppsLog
+type ReleasesChangelogs map[string]AppsChangelogs

--- a/changelog.go
+++ b/changelog.go
@@ -43,7 +43,9 @@ type Changelog struct {
 	// version bundles the given component must exist, either within the same
 	// authority or within another authority within the infrastructure. That is,
 	// Aggregate must know about it to be able to properly merge version bundles.
-	Component string `json:"component" yaml:"component"`
+	Component string `json:"component,omitempty" yaml:"component,omitempty"`
+	// ComponentVersion is the version of the exposed component.
+	ComponentVersion string `json:"componentVersion,omitempty" yaml:"componentVersion,omitempty"`
 	// Description is some text describing the changelog entry. This information
 	// is intended to be useful for humans.
 	Description string `json:"description" yaml:"description"`
@@ -53,6 +55,8 @@ type Changelog struct {
 	// URLs is a list of links which contain additional information to the
 	// changelog entry such as upstream changelogs or pull requests.
 	URLs []string `json:"urls" yaml:"urls"`
+	// Version is the version of the helm chart.
+	Version string `json:"version,omitempty" yaml:"version,omitempty"`
 }
 
 func (c Changelog) String() string {

--- a/changelog.go
+++ b/changelog.go
@@ -55,7 +55,7 @@ type Changelog struct {
 	// URLs is a list of links which contain additional information to the
 	// changelog entry such as upstream changelogs or pull requests.
 	URLs []string `json:"urls" yaml:"urls"`
-	// Version is the version of the helm chart.
+	// Version is the Giant Swarm version of the component.
 	Version string `json:"version,omitempty" yaml:"version,omitempty"`
 }
 

--- a/changelog.go
+++ b/changelog.go
@@ -44,7 +44,7 @@ type Changelog struct {
 	// authority or within another authority within the infrastructure. That is,
 	// Aggregate must know about it to be able to properly merge version bundles.
 	Component string `json:"component,omitempty" yaml:"component,omitempty"`
-	// ComponentVersion is the version of the exposed component.
+	// ComponentVersion is the upstream version of the exposed component.
 	ComponentVersion string `json:"componentVersion,omitempty" yaml:"componentVersion,omitempty"`
 	// Description is some text describing the changelog entry. This information
 	// is intended to be useful for humans.


### PR DESCRIPTION
To parse a new changelog type in cluster-service, we need a spec in versionbundle. 

See comment https://github.com/giantswarm/cluster-service/pull/409#discussion_r373380000
