### PR TITLE
Support app-only releases

### DIFF
--- a/app.go
+++ b/app.go
@@ -6,6 +6,10 @@ type App struct {
 	Version          string `yaml:"version"`
 }
 
+func (a App) AppID() string {
+	return a.App + ":" + a.Version
+}
+
 func CopyApps(apps []App) []App {
 	appList := make([]App, len(apps))
 	copy(appList, apps)

--- a/index_release.go
+++ b/index_release.go
@@ -232,7 +232,7 @@ func validateUniqueReleases(indexReleases []IndexRelease) error {
 		// Verify release version contents
 		appsAndAuthorities := make([]string, 0, len(release.Apps)+len(release.Authorities))
 		for _, a := range release.Apps {
-			appsAndAuthorities = append(appsAndAuthorities, appID(a))
+			appsAndAuthorities = append(appsAndAuthorities, a.AppID())
 		}
 		for _, a := range release.Authorities {
 			appsAndAuthorities = append(appsAndAuthorities, a.BundleID())
@@ -252,8 +252,4 @@ func validateUniqueReleases(indexReleases []IndexRelease) error {
 	}
 
 	return nil
-}
-
-func appID(a App) string {
-	return a.App + ":" + a.Version
 }

--- a/index_release.go
+++ b/index_release.go
@@ -230,15 +230,18 @@ func validateUniqueReleases(indexReleases []IndexRelease) error {
 		releaseVersions[release.Version] = release.Version
 
 		// Verify release version contents
-		authorities := make([]string, 0, len(release.Authorities))
+		appsAndAuthorities := make([]string, 0, len(release.Apps)+len(release.Authorities))
+		for _, a := range release.Apps {
+			appsAndAuthorities = append(appsAndAuthorities, appID(a))
+		}
 		for _, a := range release.Authorities {
-			authorities = append(authorities, a.BundleID())
+			appsAndAuthorities = append(appsAndAuthorities, a.BundleID())
 		}
 
-		sort.Strings(authorities)
+		sort.Strings(appsAndAuthorities)
 
 		sha256Hash.Reset()
-		sha256Hash.Write([]byte(strings.Join(authorities, ",")))
+		sha256Hash.Write([]byte(strings.Join(appsAndAuthorities, ",")))
 
 		hexHash := hex.EncodeToString(sha256Hash.Sum(nil))
 		otherVer, exists = releaseChecksums[hexHash]
@@ -249,4 +252,8 @@ func validateUniqueReleases(indexReleases []IndexRelease) error {
 	}
 
 	return nil
+}
+
+func appID(a App) string {
+	return a.App + ":" + a.Version
 }

--- a/index_release_test.go
+++ b/index_release_test.go
@@ -1960,6 +1960,66 @@ func Test_validateUniqueReleases(t *testing.T) {
 			},
 			errorMatcher: IsInvalidRelease,
 		},
+		{
+			name: "case 5: success with multiple unique releases with app diff only",
+			releases: []IndexRelease{
+				{
+					Active: false,
+					Apps: []App{
+						{
+							App:              "nginx-ingress-controller",
+							ComponentVersion: "0.30.0",
+							Version:          "1.6.0",
+						},
+					},
+					Authorities: []Authority{
+						{
+							Name:    "cert-operator",
+							Version: "0.1.0",
+						},
+						{
+							Name:     "cluster-operator",
+							Provider: "kvm",
+							Version:  "0.3.0",
+						},
+						{
+							Name:    "kvm-operator",
+							Version: "2.2.1",
+						},
+					},
+					Date:    time.Date(2018, time.May, 21, 13, 12, 00, 00, time.UTC),
+					Version: "2.6.1",
+				},
+				{
+					Active: false,
+					Apps: []App{
+						{
+							App:              "nginx-ingress-controller",
+							ComponentVersion: "0.29.0",
+							Version:          "1.5.0",
+						},
+					},
+					Authorities: []Authority{
+						{
+							Name:    "cert-operator",
+							Version: "0.1.0",
+						},
+						{
+							Name:     "cluster-operator",
+							Provider: "kvm",
+							Version:  "0.3.0",
+						},
+						{
+							Name:    "kvm-operator",
+							Version: "2.2.1",
+						},
+					},
+					Date:    time.Date(2018, time.April, 16, 12, 00, 0, 0, time.UTC),
+					Version: "2.5.1",
+				},
+			},
+			errorMatcher: nil,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
I'm trying to make a new release differing from the previous one only in app versions (a.k.a. app-only release) - opsctl release validation is failing https://circleci.com/gh/giantswarm/releases/740 complaining that the releases are not unique since validator checks just operators/authorities, while the two releases differ in apps only.

This PR adjust the release uniqueness check to support app-only releases.