### PR TITLE
Use micrologger v0.1.0

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -18,8 +18,7 @@
   revision = "e0ebc4ecf5a515b8f2a33257d08962e387120a77"
 
 [[projects]]
-  branch = "master"
-  digest = "1:c313924ca7110c452a83502384552f4dd2ed25dd0f3ab8aa8a34707315243561"
+  digest = "1:c497795cf3848ef5a655d53f24dfc670c72f9b2fc41eeda495d66542ae6bd017"
   name = "github.com/giantswarm/micrologger"
   packages = [
     ".",
@@ -27,7 +26,8 @@
     "microloggertest",
   ]
   pruneopts = "UT"
-  revision = "d866337f739365a54de5924b8a7b29df17693ef8"
+  revision = "c87486c7d20d7878ad57a09d379d7d59328b472e"
+  version = "v0.1.0"
 
 [[projects]]
   digest = "1:0cfcded8689c2c964c223650009c5dd9e283c22d57f18f2335aafa16cc22acf1"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -35,7 +35,7 @@
   name = "github.com/giantswarm/microerror"
 
 [[constraint]]
-  branch = "master"
+  version = "v0.1.0"
   name = "github.com/giantswarm/micrologger"
 
 [[constraint]]

--- a/vendor/github.com/giantswarm/micrologger/CHANGELOG.md
+++ b/vendor/github.com/giantswarm/micrologger/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] 2020-02-13
+
+### Added
+
+- First release.
+
+[Unreleased]: https://github.com/giantswarm/micrologger/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/giantswarm/micrologger/releases/tag/v0.1.0


### PR DESCRIPTION
We need to pin the micrologger dependency to the v0.1.0 version which is the one using dep instead of newer versions that use go modules.